### PR TITLE
Readonly variant voor de material formbuilder doorgevoerd

### DIFF
--- a/src/main/app/src/app/formulieren/formulier-builder.ts
+++ b/src/main/app/src/app/formulieren/formulier-builder.ts
@@ -8,6 +8,7 @@ import {AbstractFormulier} from './model/abstract-formulier';
 import {Taak} from '../taken/model/taak';
 import {Groep} from '../identity/model/groep';
 import {Observable} from 'rxjs';
+import {TaakStatus} from '../taken/model/taak-status.enum';
 
 export class FormulierBuilder {
 
@@ -28,7 +29,7 @@ export class FormulierBuilder {
     behandelForm(taak: Taak): FormulierBuilder {
         this._formulier.taak = taak;
         this._formulier.dataElementen = taak.taakdata;
-        this._formulier.initBehandelForm();
+        this._formulier.initBehandelForm(TaakStatus.Afgerond === taak.status);
         return this;
     }
 

--- a/src/main/app/src/app/formulieren/model/aanvullende-informatie.ts
+++ b/src/main/app/src/app/formulieren/model/aanvullende-informatie.ts
@@ -28,13 +28,15 @@ export class AanvullendeInformatie extends AbstractFormulier {
         ];
     }
 
-    initBehandelForm() {
+    initBehandelForm(afgerond: boolean) {
         this.form = [
             [new ReadonlyFormFieldBuilder().id(Fields.TOELICHTING).label(Fields.TOELICHTING).value(this.getDataElement(Fields.TOELICHTING)).build()],
             [new TextareaFormFieldBuilder().id(Fields.OPGEVRAAGDEINFO).label(Fields.OPGEVRAAGDEINFO).value(this.getDataElement(Fields.OPGEVRAAGDEINFO))
-                                           .validators(Validators.required).build()],
-            [new DateFormFieldBuilder().id(Fields.DATUMGEVRAAGD).label(Fields.DATUMGEVRAAGD).build(),
-                new DateFormFieldBuilder().id(Fields.DATUMGELEVERD).label(Fields.DATUMGELEVERD).build()]
+                                           .validators(Validators.required).readonly(afgerond).build()],
+            [new DateFormFieldBuilder().id(Fields.DATUMGEVRAAGD).label(Fields.DATUMGEVRAAGD).value(this.getDataElement(Fields.DATUMGEVRAAGD)).readonly(afgerond)
+                                       .build(),
+                new DateFormFieldBuilder().id(Fields.DATUMGELEVERD).label(Fields.DATUMGELEVERD).value(this.getDataElement(Fields.DATUMGELEVERD))
+                                          .readonly(afgerond).build()]
         ];
     }
 

--- a/src/main/app/src/app/formulieren/model/abstract-formulier.ts
+++ b/src/main/app/src/app/formulieren/model/abstract-formulier.ts
@@ -17,6 +17,7 @@ export abstract class AbstractFormulier {
     planItem: PlanItem;
     taak: Taak;
     dataElementen: {};
+    afgerond: boolean;
 
     abstract form: Array<AbstractFormField[]>;
 
@@ -24,7 +25,7 @@ export abstract class AbstractFormulier {
 
     abstract initStartForm();
 
-    abstract initBehandelForm();
+    abstract initBehandelForm(afgerond: boolean);
 
     getPlanItem(formGroup: FormGroup): PlanItem {
         this.planItem.groep = formGroup.controls['groep']?.value;
@@ -48,7 +49,9 @@ export abstract class AbstractFormulier {
         const dataElementen: {} = {};
 
         Object.keys(formGroup.controls).forEach((key) => {
-            dataElementen[key] = formGroup.controls[key]?.value;
+            if (key !== 'groep') {
+                dataElementen[key] = formGroup.controls[key]?.value;
+            }
         });
 
         return dataElementen;

--- a/src/main/app/src/app/formulieren/model/advies.ts
+++ b/src/main/app/src/app/formulieren/model/advies.ts
@@ -27,12 +27,14 @@ export class Advies extends AbstractFormulier {
         ];
     }
 
-    initBehandelForm() {
+    initBehandelForm(afgerond: boolean) {
         this.form = [
             [new ReadonlyFormFieldBuilder().id(Fields.VRAAG).label(Fields.VRAAG).value(this.getDataElement(Fields.VRAAG)).build()],
-            [new TextareaFormFieldBuilder().id(Fields.TOELICHTING).label(Fields.TOELICHTING).value(this.getDataElement(Fields.TOELICHTING)).build()],
-            [new FileFormFieldBuilder().id(Fields.BIJLAGE).label(Fields.BIJLAGE).config(this.fileUploadConfig()).build()]
+            [new TextareaFormFieldBuilder().id(Fields.TOELICHTING).label(Fields.TOELICHTING).value(this.getDataElement(Fields.TOELICHTING)).readonly(afgerond)
+                                           .build()],
+            [new FileFormFieldBuilder().id(Fields.BIJLAGE).label(Fields.BIJLAGE).config(this.fileUploadConfig()).readonly(afgerond).build()]
         ];
+
     }
 
     fileUploadConfig(): FileFieldConfig {

--- a/src/main/app/src/app/shared/edit/edit.component.less
+++ b/src/main/app/src/app/shared/edit/edit.component.less
@@ -20,7 +20,7 @@
 
 .form-buttons {
   display: flex;
-  justify-content: end;
+  justify-content: flex-end;
 }
 
 .static-text {

--- a/src/main/app/src/app/shared/material-form-builder/form/form-field/form-field.component.ts
+++ b/src/main/app/src/app/shared/material-form-builder/form/form-field/form-field.component.ts
@@ -6,6 +6,8 @@
 import {AfterViewInit, Component, ComponentFactoryResolver, Input, ViewChild} from '@angular/core';
 import {FormItem} from '../../model/form-item';
 import {FormFieldDirective} from './form-field.directive';
+import {ReadonlyFormFieldBuilder} from '../../form-components/readonly/readonly-form-field-builder';
+import {ReadonlyComponent} from '../../form-components/readonly/readonly.component';
 
 @Component({
     selector: 'mfb-form-field',
@@ -25,6 +27,11 @@ export class FormFieldComponent implements AfterViewInit {
     }
 
     loadComponent() {
+        if (this.field.data.readonly) {
+            this.field = new FormItem(ReadonlyComponent,
+                new ReadonlyFormFieldBuilder().id(this.field.data.id).label(this.field.data.label).value(this.field.data.formControl.value)
+                                              .build());
+        }
         // create component with ComponentFactory
         const componentFactory = this.componentFactoryResolver.resolveComponentFactory(this.field.component);
         const componentRef = this.formField.viewContainerRef.createComponent(componentFactory);

--- a/src/main/app/src/app/shared/material-form-builder/form/form/form.component.html
+++ b/src/main/app/src/app/shared/material-form-builder/form/form/form.component.html
@@ -13,7 +13,7 @@
         </div>
     </ng-container>
 
-    <div fxLayout="row" fxLayoutAlign="start">
+    <div fxLayout="row" fxLayoutAlign="start" *ngIf="config">
         <button mat-flat-button color="accent"
                 *ngIf="config.partialButtonText || config.partialButtonIcon"
                 [disabled]="formGroup.invalid"

--- a/src/main/app/src/app/shared/material-form-builder/model/abstract-form-field-builder.ts
+++ b/src/main/app/src/app/shared/material-form-builder/model/abstract-form-field-builder.ts
@@ -24,6 +24,11 @@ export abstract class AbstractFormFieldBuilder {
         return this;
     }
 
+    readonly(readonly: boolean): this {
+        this.formField.readonly = readonly;
+        return this;
+    }
+
     value(value: any): this {
         this.formField.formControl.setValue(value);
         return this;

--- a/src/main/app/src/app/shared/material-form-builder/model/abstract-form-field.ts
+++ b/src/main/app/src/app/shared/material-form-builder/model/abstract-form-field.ts
@@ -11,6 +11,7 @@ export abstract class AbstractFormField {
     id: string;
     label: string;
     required: boolean;
+    readonly: boolean;
 
     private readonly _formControl: FormControl = new FormControl();
     private _hint: FormFieldHint;


### PR DESCRIPTION
Elk formfield heeft nu de optie om readonly(true|false) in te stellen. Indien true wordt het formfield vervangen door een ReadonlyFormField.

fixes #48