### PR TITLE
zaakafhandelcomponent-523 BUG: Documenten worden vaker opgeslagen

### DIFF
--- a/src/main/app/src/app/shared/material-form-builder/form/form/form.component.html
+++ b/src/main/app/src/app/shared/material-form-builder/form/form/form.component.html
@@ -16,14 +16,17 @@
     <div fxLayout="row" fxLayoutAlign="start" *ngIf="config">
         <button mat-flat-button color="accent"
                 *ngIf="config.partialButtonText || config.partialButtonIcon"
-                [disabled]="formGroup.invalid"
-                (click)="partial()" id="partial_button"
-                type="button">
+                [class.busy]="submittingPartial"
+                [disabled]="formGroup.invalid||submitting"
+                id="partial_button"
+                type="button"
+                (click)="partial()">
             <mat-icon *ngIf="config.partialButtonIcon">{{config.partialButtonIcon}}</mat-icon>
             {{config.partialButtonText | translate}}
         </button>
         <button mat-flat-button color="primary"
-                [disabled]="formGroup.invalid"
+                [class.busy]="submittingForm"
+                [disabled]="formGroup.invalid||submitting"
                 id="opslaan_button"
                 type="submit">
             <mat-icon *ngIf="config.saveButtonIcon">{{config.saveButtonIcon}}</mat-icon>
@@ -31,8 +34,10 @@
         </button>
         <button mat-flat-button
                 *ngIf="config.cancelButtonText || config.cancelButtonIcon"
-                (click)="cancel()" id="annuleren_button"
-                type="button">
+                [disabled]="submitting"
+                id="annuleren_button"
+                type="button"
+                (click)="cancel()">
             <mat-icon *ngIf="config.cancelButtonIcon">{{config.cancelButtonIcon}}</mat-icon>
             {{config.cancelButtonText | translate}}
         </button>

--- a/src/main/app/src/app/shared/material-form-builder/form/form/form.component.less
+++ b/src/main/app/src/app/shared/material-form-builder/form/form/form.component.less
@@ -2,6 +2,8 @@
  * SPDX-FileCopyrightText: 2021 Atos
  * SPDX-License-Identifier: EUPL-1.2+
  */
+@import "src/variables";
+
 :host ::ng-deep mat-form-field .mat-form-field {
   &-underline {
     position: static;
@@ -10,4 +12,26 @@
   &-subscript-wrapper {
     position: static;
   }
+}
+
+@keyframes busy {
+  to {
+    transform: rotate(180deg);
+  }
+}
+
+.busy:before {
+  content: "";
+  box-sizing: border-box;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 20px;
+  height: 20px;
+  margin-top: -10px;
+  margin-left: -10px;
+  border-radius: 50%;
+  border: 10px solid;
+  border-color: @primary-background-color @primary-text-color;
+  animation: busy .35s linear infinite;
 }

--- a/src/main/app/src/app/shared/material-form-builder/form/form/form.component.ts
+++ b/src/main/app/src/app/shared/material-form-builder/form/form/form.component.ts
@@ -33,6 +33,9 @@ export class FormComponent {
 
     data: Array<AbstractFormField[]>;
     formGroup: FormGroup;
+    submitting: boolean;
+    submittingPartial: boolean;
+    submittingForm: boolean;
 
     private _config: FormConfig;
 
@@ -53,14 +56,17 @@ export class FormComponent {
     }
 
     partial() {
+        this.submitting = this.submittingPartial = true;
         this.formPartial.emit(this.formGroup);
     }
 
     submit(): void {
+        this.submitting = this.submittingForm = true;
         this.formSubmit.emit(this.formGroup);
     }
 
     cancel(): void {
+        this.submitting = true;
         this.formSubmit.emit(null);
     }
 }


### PR DESCRIPTION
Generiek opgelost voor alle formulieren. De knoppen onderaan het formulier worden gedisabled nadat je er op geklik hebt en de knop waarop je geklikt hebt krijgt een spinner, zodat je kunt zien dat je ergens op wacht als gebruiker.