### PR TITLE
zaakafhandelcomponent-599 BUG: email controle wordt niet gedaan

### DIFF
--- a/src/main/app/src/app/mail/mail-create/mail-create.component.ts
+++ b/src/main/app/src/app/mail/mail-create/mail-create.component.ts
@@ -22,6 +22,7 @@ import {Medewerker} from '../../identity/model/medewerker';
 import {IdentityService} from '../../identity/identity.service';
 import {MailService} from '../mail.service';
 import {MailObject} from '../model/mailobject';
+import {CustomValidators} from '../../shared/validators/customValidators';
 
 @Component({
     templateUrl: './mail-create.component.html'
@@ -56,7 +57,8 @@ export class MailCreateComponent implements OnInit {
         this.zakenService.readZaak(this.zaakUuid).subscribe(zaak => {
             this.zaak = zaak;
             this.utilService.setTitle('title.mail.versturen', {zaak: zaak.identificatie});
-            const ontvanger = new InputFormFieldBuilder().id('ontvanger').label('ontvanger').validators(Validators.required).build();
+            const ontvanger = new InputFormFieldBuilder().id('ontvanger').label('ontvanger')
+                                                         .validators(Validators.required, CustomValidators.emails).build();
             const onderwerp = new InputFormFieldBuilder().id('onderwerp').label('onderwerp').validators(Validators.required).build();
             const body = new TextareaFormFieldBuilder().id('body').label('body').validators(Validators.required).build();
             this.fields = [[ontvanger], [onderwerp], [body]];

--- a/src/main/app/src/app/shared/validators/customValidators.ts
+++ b/src/main/app/src/app/shared/validators/customValidators.ts
@@ -13,8 +13,17 @@ export class CustomValidators {
     static vestigingsnummer = CustomValidators.vestigingsnummerVFn();
     static bsnPrefixed = CustomValidators.bsnVFn(true);
     static bsnOrVesPrefixed = CustomValidators.bsnOfVestigingVFn(true);
+    static email = CustomValidators.emailVFn(false);
+    static emails = CustomValidators.emailVFn(true);
 
     private static postcodeRegex = /^[1-9][0-9]{3}(?!sa|sd|ss)[a-z]{2}$/i;
+
+    private static ID = 'A-Za-z\\d';
+    private static LCL = '[' + CustomValidators.ID + '!#$%&\'*+\\-/=?^_`{|}~]+';
+    private static LBL = '[' + CustomValidators.ID + ']([' + CustomValidators.ID + '\\-]*[' + CustomValidators.ID + '])?';
+    private static EMAIL = CustomValidators.LCL + '(\\.' + CustomValidators.LCL + ')*@' + CustomValidators.LBL + '(\\.' + CustomValidators.LBL + ')+';
+    private static emailRegex = new RegExp('^' + CustomValidators.EMAIL + '$');
+    private static emailsRegex = new RegExp('^(' + CustomValidators.EMAIL + ')(;//s*' + CustomValidators.EMAIL + ')*$');
 
     private static bsnVFn(allowPrefix = false): ValidatorFn {
         return (control: AbstractControl): { [key: string]: boolean } | null => {
@@ -66,6 +75,18 @@ export class CustomValidators {
             const val = control.value;
             if (!CustomValidators.postcodeRegex.test(val)) {
                 return {postcode: true};
+            }
+        };
+    }
+
+    private static emailVFn(multi: boolean): ValidatorFn {
+        return (control: AbstractControl): { [key: string]: boolean } | null => {
+            if (!control.value) {
+                return null;
+            }
+            const val = control.value;
+            if (multi ? !CustomValidators.emailsRegex.test(val) : !CustomValidators.emailRegex.test(val)) {
+                return {email: true};
             }
         };
     }


### PR DESCRIPTION
Reguliere expressies overgenomen uit de eSuite. In overleg met Roy de validate voor meerdere E-Mail adressen ( ;- gescheiden) erop gezet. Maar de validator voor een enkel E-Mail-adres is ook beschikbaar. 