### PR TITLE
zaakafhandelcomponent-1344 deactiveer versturen ontvangsbevestiging voor heropende zaken

### DIFF
--- a/src/main/resources/policies/zaak-acties.rego
+++ b/src/main/resources/policies/zaak-acties.rego
@@ -108,6 +108,7 @@ versturen_email {
 default versturen_ontvangstbevestiging := false
 versturen_ontvangstbevestiging {
     zaak.open == true
+    zaak.heropend == false
     zaaktype_allowed == true
 }
 


### PR DESCRIPTION
Het versturen van een ontvangstbevestiging bij open zaken werkt prima. Alleen bij heropende zaken gaat er iets mis. Dit is opgelost door een rule toe te voegen aan de OPA-configuratie voor de `versturenOntvangstbevestiging` actie. Deze wordt beide in de front- en back-end gecontroleerd. Het versturen van een ontvangstbevestiging voor heropende zaken is met deze diff dus daadwerkelijk onmogelijk, waardoor de bug niet meer voorkomt.