### PR TITLE
zaakafhandelcomponent-1288 verwijder overbodig geworden datum-pipe

### DIFF
--- a/src/main/app/src/app/informatie-objecten/informatie-object-view/informatie-object-view.component.html
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-view/informatie-object-view.component.html
@@ -128,13 +128,13 @@
                                     <ng-container matColumnDef="oudeWaarde">
                                         <th mat-header-cell *matHeaderCellDef> {{'waarde.oud' | translate}} </th>
                                         <td mat-cell *matCellDef="let regel">
-                                            <read-more [text]="regel.oudeWaarde | datum:'short' | empty" [maxLength]="20"></read-more>
+                                            <read-more [text]="regel.oudeWaarde | empty" [maxLength]="20"></read-more>
                                         </td>
                                     </ng-container>
                                     <ng-container matColumnDef="nieuweWaarde">
                                         <th mat-header-cell *matHeaderCellDef> {{'waarde.nieuw' | translate}} </th>
                                         <td mat-cell *matCellDef="let regel">
-                                            <read-more [text]="regel.nieuweWaarde | datum:'short' | empty" [maxLength]="20"></read-more>
+                                            <read-more [text]="regel.nieuweWaarde | empty" [maxLength]="20"></read-more>
                                         </td>
                                     </ng-container>
                                     <ng-container matColumnDef="toelichting">

--- a/src/main/app/src/app/taken/taak-view/taak-view.component.html
+++ b/src/main/app/src/app/taken/taak-view/taak-view.component.html
@@ -90,14 +90,14 @@
                                         <ng-container matColumnDef="oudeWaarde">
                                             <th mat-header-cell *matHeaderCellDef> {{'waarde.oud' | translate}} </th>
                                             <td mat-cell *matCellDef="let regel">
-                                                <read-more [text]="regel.oudeWaarde | datum | empty"
+                                                <read-more [text]="regel.oudeWaarde | empty"
                                                            [maxLength]="20"></read-more>
                                             </td>
                                         </ng-container>
                                         <ng-container matColumnDef="nieuweWaarde">
                                             <th mat-header-cell *matHeaderCellDef> {{'waarde.nieuw' | translate}} </th>
                                             <td mat-cell *matCellDef="let regel">
-                                                <read-more [text]="regel.nieuweWaarde | datum | empty"
+                                                <read-more [text]="regel.nieuweWaarde | empty"
                                                            [maxLength]="20"></read-more>
                                             </td>
                                         </ng-container>


### PR DESCRIPTION
In een vroeger stadium werd de conversie van een String-representatie van een `LocalDate`-/`ZonedDateTime`-object bij historie-regels gedaan in de front-end d.m.v. de `datum` pipe. In de huidige situatie wordt deze conversie al in de back-end gedaan d.m.v. een formatter, waardoor meerdere soorten data correct getoond kunnen worden en naar de front-end gestuurd worden als String.

De bug ontstaat wanneer een waarde die geen datum representeert naar de front-end wordt gestuurd, en wordt getoond op een pagina waar deze historische `datum`-pipe nog steeds aanwezig is. Op dat moment probeert deze pipe de data hoe dan ook te converteren naar een valide datum, waardoor een waarde als `1234` ineens getoond wordt als `01-01-1234`.

Om dit te voorkomen is gezocht op de usages van `historie-regel.ts`. Hieruit blijkt dat - zoals Hans al aangaf - bij de zaak-view de overbodig geworden pipe al is verwijderd, maar bij de taak-view en informatieobject-view nog niet. Deze zijn in deze diff ook verwijderd.