### PR TITLE
zaakafhandelcomponent-1342 suspend zaaklistener bij afbreken zaak

### DIFF
--- a/src/main/app/src/app/core/websocket/websocket.service.ts
+++ b/src/main/app/src/app/core/websocket/websocket.service.ts
@@ -176,6 +176,12 @@ export class WebsocketService implements OnDestroy {
         this.suspendListener(listener);
     }
 
+    public tripleSuspendListener(listener: WebsocketListener) {
+        this.suspendListener(listener);
+        this.suspendListener(listener);
+        this.suspendListener(listener);
+    }
+
     public removeListener(listener: WebsocketListener): void {
         if (listener) {
             this.removeCallback(listener);

--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
@@ -564,9 +564,11 @@ export class ZaakViewComponent extends ActionsViewComponent implements OnInit, A
                                             .options(this.zaakafhandelParametersService.listZaakbeeindigRedenenForZaaktype(this.zaak.zaaktype.uuid))
                                             .validators(Validators.required)
                                             .build()],
-            (results: any[]) => this.zakenService.afbreken(this.zaak.uuid, results['reden']).pipe(
-                tap(() => this.websocketService.suspendListener(this.zaakListener))
-            ));
+            (results: any[]) => {
+                    this.websocketService.tripleSuspendListener(this.zaakListener);
+                    return this.zakenService.afbreken(this.zaak.uuid, results['reden']);
+                }
+            );
 
         dialogData.confirmButtonActionKey = 'actie.zaak.afbreken';
 


### PR DESCRIPTION
Er worden drie overbodige snackbarren over een wijziging op de zaak getoond. Om alle drie van deze snackbarren te kunnen verbergen, lijkt het er op dat er daadwerkelijk drie keer suspend moet worden aangeroepen**. Hiervoor heb ik een klein beetje duplicaat-code geintroduceerd, wat in mijn ogen in dit geval wel acceptabel is omdat ik verwacht dat in de toekomst _**geen**_ `quadrupleSuspendListener` of nog erger niet nodig zal zijn. Deze oplossing is ook even besproken in de daily standup van vandaag (29 juli 2022). Hierbij benoemde Andy ook dat dit best wel eens de correcte oplossing kan zijn, ook al ziet het er ietwat _hacky_ uit.

** Bij het reproduceren lijkt het er op dat het verplaatsen van de suspend naar _voor_ het aanroepen van de zaak-afbreken-methode er voor zorgt dat er nog twee overbodige snackbarren worden getoond. Het vervolgens vervangen van de `suspendListener`-methode voor de al bestaande `doubleSuspendListener`-methode zorgt er voor dat er nog maar &eacute;&eacute;n overbodige snackbar wordt getoond. De nieuwe `tripleSuspendListener` zorgt er voor dat alle drie de overbodige snackbarren worden verborgen.