### PR TITLE
zaakafhandelcomponent-315 websocket suspenden bij taak aanmaken

### DIFF
--- a/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
+++ b/src/main/app/src/app/zaken/zaak-view/zaak-view.component.ts
@@ -767,8 +767,6 @@ export class ZaakViewComponent extends ActionsViewComponent implements OnInit, A
         if (event) {
             console.log('callback loadTaken: ' + event.key);
         }
-        // TODO #315
-        this.websocketService.suspendListener(this.zaakTakenListener);
 
         this.taken$ = this.takenService.listTakenVoorZaak(this.zaak.uuid)
                           .pipe(
@@ -935,6 +933,7 @@ export class ZaakViewComponent extends ActionsViewComponent implements OnInit, A
     }
 
     taakGestart(): void {
+        this.websocketService.suspendListener(this.zaakTakenListener);
         this.actiefPlanItem = null;
         this.actionsSidenav.close();
         this.updateZaak();


### PR DESCRIPTION
Er was al een output event `done` op het `human-task-do`-component, die ook al is geregistreerd in het `zaak-view`-component. In dat component wordt de methode `taakGestart` aangeroepen om o.a. de sidenav weer af te sluiten. De bestaande suspend-call is verplaatst naar deze methode om te zorgen dat de snackbar van de notification voor het aanmaken van een taak niet getoond wordt.