### PR TITLE
zaakafhandelcomponent-1521 Zorg dat opgegeven reden ook in toelichting wordt getoond

### DIFF
--- a/src/main/java/net/atos/zac/app/zaken/ZakenRESTService.java
+++ b/src/main/java/net/atos/zac/app/zaken/ZakenRESTService.java
@@ -334,8 +334,9 @@ public class ZakenRESTService {
         } else {
             assertActie(policyService.readZaakActies(zaakUUID).getHervatten());
         }
-        final Zaak updatedZaak = zrcClientService.updateZaak(zaakUUID, zaakConverter.convertToPatch(restZaakOpschortGegevens),
-                                                             restZaakOpschortGegevens.indicatieOpschorting ? OPSCHORTING : HERVATTING);
+        final String toelichting = String.format("%s: %s", restZaakOpschortGegevens.indicatieOpschorting ?
+                OPSCHORTING : HERVATTING, restZaakOpschortGegevens.redenOpschorting);
+        final Zaak updatedZaak = zrcClientService.updateZaak(zaakUUID, zaakConverter.convertToPatch(restZaakOpschortGegevens), toelichting);
         if (restZaakOpschortGegevens.indicatieOpschorting) {
             caseVariablesService.setDatumtijdOpgeschort(zaakUUID, ZonedDateTime.now());
             caseVariablesService.setVerwachteDagenOpgeschort(zaakUUID, restZaakOpschortGegevens.duurDagen);
@@ -360,7 +361,8 @@ public class ZakenRESTService {
     @Path("zaak/{uuid}/verlenging")
     public RESTZaak verlengenZaak(@PathParam("uuid") final UUID zaakUUID, final RESTZaakVerlengGegevens restZaakVerlengGegevens) {
         assertActie(policyService.readZaakActies(zaakUUID).getVerlengen());
-        final Zaak updatedZaak = zrcClientService.updateZaak(zaakUUID, zaakConverter.convertToPatch(zaakUUID, restZaakVerlengGegevens), VERLENGING);
+        final String toelichting = String.format("%s: %s", VERLENGING, restZaakVerlengGegevens.redenVerlenging);
+        final Zaak updatedZaak = zrcClientService.updateZaak(zaakUUID, zaakConverter.convertToPatch(zaakUUID, restZaakVerlengGegevens), toelichting);
         if (restZaakVerlengGegevens.takenVerlengen) {
             final int aantalTakenVerlengd = verlengOpenTaken(zaakUUID, restZaakVerlengGegevens.duurDagen);
             if (aantalTakenVerlengd > 0) {


### PR DESCRIPTION
Toelichting wordt nu opgebouwd uit prefix en reden, in plaats van alleen de prefix te tonen. Er wordt geen check uitgevoerd of de reden wel of niet is ingevuld, aangezien deze invoervelden in de front-end verplicht zijn.