### PR TITLE
zaakafhandelcomponent-1546 Verander koptekst bij zaak aanmaken sectie naar gewenste tekst

### DIFF
--- a/src/main/app/src/assets/i18n/en.json
+++ b/src/main/app/src/assets/i18n/en.json
@@ -116,7 +116,7 @@
   "gegevens.overig" : "Other information",
   "gegevens.humantasks" : "Task information",
   "gegevens.acties" : "Action information",
-  "gegevens.toekennen" : "Assignment information",
+  "gegevens.toekennen" : "Case assignment",
   "goedkeuren" : "Approve",
   "geldig" : "Valid",
   "begin.geldigheid" : "Start validity",

--- a/src/main/app/src/assets/i18n/nl.json
+++ b/src/main/app/src/assets/i18n/nl.json
@@ -116,7 +116,7 @@
   "gegevens.overig" : "Overige gegevens",
   "gegevens.humantasks" : "Taak gegevens",
   "gegevens.acties" : "Actie gegevens",
-  "gegevens.toekennen" : "Toekenning gegevens",
+  "gegevens.toekennen" : "Zaaktoewijzing",
   "goedkeuren" : "Goedkeuren",
   "geldig" : "Geldig",
   "begin.geldigheid" : "Begin geldigheid",


### PR DESCRIPTION
Fixes https://github.com/NL-AMS-LOCGOV/zaakafhandelcomponent/issues/1546

In issueomschrijving staat `Zaaktoekenning`, maar in oorspronkelijke refinement-comment staat `Zaaktoewijzing`. In overleg met Robert de laatste optie gekozen.