### PR TITLE
zaakafhandelcomponent-1592 Reden verplicht bij ontkoppelen document

### DIFF
--- a/src/main/app/src/app/zaken/zaak-documenten/zaak-documenten.component.ts
+++ b/src/main/app/src/app/zaken/zaak-documenten/zaak-documenten.component.ts
@@ -30,6 +30,7 @@ import {InformatieObjectVerplaatsService} from '../../informatie-objecten/inform
 import {GekoppeldeZaakEnkelvoudigInformatieobject} from '../../informatie-objecten/model/gekoppelde.zaak.enkelvoudig.informatieobject';
 import {SelectionModel} from '@angular/cdk/collections';
 import {MatCheckboxChange} from '@angular/material/checkbox';
+import {Validators} from '@angular/forms';
 
 @Component({
     selector: 'zac-zaak-documenten',
@@ -130,6 +131,7 @@ export class ZaakDocumentenComponent implements OnInit, AfterViewInit, OnDestroy
                 const dialogData = new DialogData([
                         new TextareaFormFieldBuilder().id('reden')
                                                       .label('reden')
+                                                      .validators(Validators.required)
                                                       .build()],
                     (results: any[]) => this.zakenService.ontkoppelInformatieObject(this.zaak.uuid, informatieobject.uuid, results['reden']),
                     melding);


### PR DESCRIPTION
Wijziging aan de back-end kant is niet nodig. De methode die wordt aangeroepen is `ZakenRESTService::ontkoppelInformatieObject`. In die methode wordt de `reden` alleen gebruikt in een call naar `ZRCClientService::deleteZaakInformatieObject` (welke door meerdere andere methodes wordt aangeroepen, dus de null-check mag hier blijven staan) en een call naar `OntkoppeldeDocumentenService::create` (waar de reden direct geset wordt op het object zonder null-check oid).