### PR TITLE
zaakafhandelcomponent-1953 Fix updaten ontvangst- en verzenddatum

### DIFF
--- a/src/main/app/src/app/informatie-objecten/informatie-object-edit/informatie-object-edit.component.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-edit/informatie-object-edit.component.ts
@@ -164,7 +164,7 @@ export class InformatieObjectEditComponent implements OnInit, OnDestroy {
 
         if (ontvangstDatum.formControl.value) {
             verzenddatum.formControl.disable();
-            //TODO: window.setTimeout verwijderen als angular versie >= 15
+            //TODO (zie Issue #2021): window.setTimeout verwijderen als angular versie >= 15
             // Bug in Angular 14 zorgt dat .disable() op sommige formControls pas werkt na repaint
             window.setTimeout(() => status.formControl.disable());
         }

--- a/src/main/app/src/app/informatie-objecten/informatie-object-edit/informatie-object-edit.component.ts
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-edit/informatie-object-edit.component.ts
@@ -109,11 +109,11 @@ export class InformatieObjectEditComponent implements OnInit, OnDestroy {
                                                                                    .label('verzenddatum')
                                                                                    .build();
 
-        const ontvangstDatum = new DateFormFieldBuilder().id('ontvangstdatum')
-                                                         .label('ontvangstdatum')
-                                                         .hint(new FormFieldHint(this.translateService.instant(
-                                                             'msg.document.ontvangstdatum.hint')))
-                                                         .build();
+        const ontvangstDatum = new DateFormFieldBuilder(this.infoObject.ontvangstdatum).id('ontvangstdatum')
+                                                                                       .label('ontvangstdatum')
+                                                                                       .hint(new FormFieldHint(this.translateService.instant(
+                                                                                           'msg.document.ontvangstdatum.hint')))
+                                                                                       .build();
 
         const auteur = new InputFormFieldBuilder(this.ingelogdeMedewerker.naam).id('auteur').label('auteur')
                                                                                .validators(Validators.required)
@@ -157,13 +157,19 @@ export class InformatieObjectEditComponent implements OnInit, OnDestroy {
         this.subscriptions$.push(verzenddatum.formControl.valueChanges.subscribe(value => {
             if (value && ontvangstDatum.formControl.enabled) {
                 ontvangstDatum.formControl.disable();
-            } else if (!value && ontvangstDatum.formControl.disabled && !this.infoObject.verzenddatum) {
+            } else if (!value && ontvangstDatum.formControl.disabled) {
                 ontvangstDatum.formControl.enable();
             }
         }));
 
-        if (verzenddatum.formControl.value || this.infoObject.verzenddatum) {
-            ontvangstDatum.formControl.disable(verzenddatum.formControl.value);
+        if (ontvangstDatum.formControl.value) {
+            verzenddatum.formControl.disable();
+            //TODO: window.setTimeout verwijderen als angular versie >= 15
+            // Bug in Angular 14 zorgt dat .disable() op sommige formControls pas werkt na repaint
+            window.setTimeout(() => status.formControl.disable());
+        }
+        if (verzenddatum.formControl.value) {
+            ontvangstDatum.formControl.disable();
         }
     }
 

--- a/src/main/app/src/app/informatie-objecten/model/enkelvoudig-informatie-object-versie-gegevens.ts
+++ b/src/main/app/src/app/informatie-objecten/model/enkelvoudig-informatie-object-versie-gegevens.ts
@@ -16,5 +16,6 @@ export class EnkelvoudigInformatieObjectVersieGegevens {
     taal: Taal;
     bestandsnaam: string;
     verzenddatum: string;
+    ontvangstdatum: string;
     toelichting: string;
 }

--- a/src/main/java/net/atos/client/zgw/drc/model/AbstractEnkelvoudigInformatieobject.java
+++ b/src/main/java/net/atos/client/zgw/drc/model/AbstractEnkelvoudigInformatieobject.java
@@ -13,6 +13,7 @@ import java.time.ZonedDateTime;
 import java.util.UUID;
 
 import javax.json.bind.annotation.JsonbDateFormat;
+import javax.json.bind.annotation.JsonbProperty;
 import javax.json.bind.annotation.JsonbTransient;
 
 import net.atos.client.zgw.shared.model.Vertrouwelijkheidaanduiding;
@@ -136,6 +137,7 @@ public abstract class AbstractEnkelvoudigInformatieobject {
      * Ontvangst en verzending is voorbehouden aan documenten die van of naar andere personen ontvangen of verzonden zijn
      * waarbij die personen niet deel uit maken van de behandeling van de zaak waarin het document een rol speelt.
      */
+    @JsonbProperty(nillable = true)
     private LocalDate ontvangstdatum;
 
     /**
@@ -145,6 +147,7 @@ public abstract class AbstractEnkelvoudigInformatieobject {
      * Ontvangst en verzending is voorbehouden aan documenten die van of naar andere personen ontvangen of verzonden zijn
      * waarbij die personen niet deel uit maken van de behandeling van de zaak waarin het document een rol speelt.
      */
+    @JsonbProperty(nillable = true)
     private LocalDate verzenddatum;
 
     /**

--- a/src/main/java/net/atos/zac/app/informatieobjecten/converter/RESTInformatieobjectConverter.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/converter/RESTInformatieobjectConverter.java
@@ -237,6 +237,7 @@ public class RESTInformatieobjectConverter {
 
         restEnkelvoudigInformatieObjectVersieGegevens.beschrijving = informatieobject.getBeschrijving();
         restEnkelvoudigInformatieObjectVersieGegevens.verzenddatum = informatieobject.getVerzenddatum();
+        restEnkelvoudigInformatieObjectVersieGegevens.ontvangstdatum = informatieobject.getOntvangstdatum();
         restEnkelvoudigInformatieObjectVersieGegevens.titel = informatieobject.getTitel();
         restEnkelvoudigInformatieObjectVersieGegevens.auteur = informatieobject.getAuteur();
         configuratieService.findTaal(informatieobject.getTaal())


### PR DESCRIPTION
Fixes #1953.

De toegevoegde TODO heeft twee gelinkte issues. Enerzijds https://github.com/NL-AMS-LOCGOV/zaakafhandelcomponent/issues/2020 voor het updaten van de Angular-versie naar v15, anderzijds https://github.com/NL-AMS-LOCGOV/zaakafhandelcomponent/issues/2021 voor het verwijderen van de workaroud die in deze diff is toegepast.