### PR TITLE
zaakafhandelcomponent-1998 Zaak aanmaken - zaaktype selecteren

### DIFF
--- a/docs/test.md
+++ b/docs/test.md
@@ -1,4 +1,0 @@
-### Heading
-*bold*
-- itemn 1
-- item 2

--- a/src/main/app/src/app/admin/mailtemplate/mailtemplate.component.ts
+++ b/src/main/app/src/app/admin/mailtemplate/mailtemplate.component.ts
@@ -20,6 +20,8 @@ import {SelectFormFieldBuilder} from '../../shared/material-form-builder/form-co
 import {AbstractFormControlField} from '../../shared/material-form-builder/model/abstract-form-control-field';
 import {Mail} from '../model/mail';
 import {MailtemplateVariabeleUtil} from '../model/mailtemplate-variabele';
+import {ReadonlyFormFieldBuilder} from '../../shared/material-form-builder/form-components/readonly/readonly-form-field-builder';
+import {TranslateService} from '@ngx-translate/core';
 
 @Component({
     templateUrl: './mailtemplate.component.html',
@@ -51,7 +53,8 @@ export class MailtemplateComponent extends AdminComponent implements OnInit, Aft
                 private service: MailtemplateBeheerService,
                 public utilService: UtilService,
                 private route: ActivatedRoute,
-                private router: Router) {
+                private router: Router,
+                private translateService: TranslateService) {
         super(utilService);
     }
 
@@ -69,21 +72,26 @@ export class MailtemplateComponent extends AdminComponent implements OnInit, Aft
 
     createForm() {
         const mails = this.utilService.getEnumAsSelectList('mail', Mail);
-        const mail = mails.find(type => this.template.mail === type.value);
 
         this.naamFormField = new InputFormFieldBuilder(this.template.mailTemplateNaam)
         .id(this.fields.NAAM)
         .label(this.fields.NAAM)
         .validators(Validators.required)
         .build();
-        this.mailFormField = new SelectFormFieldBuilder(mail ? mail.label : null)
-        .id(this.fields.MAIL)
-        .label(this.fields.MAIL)
-        .readonly(mail != null)
-        .optionLabel('label')
-        .options(mails)
-        .validators(Validators.required)
-        .build();
+        if (this.template.mail) {
+            this.mailFormField = new ReadonlyFormFieldBuilder(this.translateService.instant('mail.' + this.template.mail))
+            .id(this.fields.MAIL)
+            .label(this.fields.MAIL)
+            .build();
+        } else {
+            this.mailFormField = new SelectFormFieldBuilder()
+            .id(this.fields.MAIL)
+            .label(this.fields.MAIL)
+            .optionLabel('label')
+            .options(mails)
+            .validators(Validators.required)
+            .build();
+        }
         this.onderwerpFormField = new HtmlEditorFormFieldBuilder(this.template.onderwerp)
         .id(this.fields.ONDERWERP)
         .label(this.fields.ONDERWERP)

--- a/src/main/app/src/app/admin/parameter-edit/parameter-edit.component.html
+++ b/src/main/app/src/app/admin/parameter-edit/parameter-edit.component.html
@@ -8,7 +8,7 @@
         <zac-side-nav (mode)="menuModeChanged($event)" [menu]="menu"></zac-side-nav>
     </mat-sidenav>
     <mat-sidenav-content fxLayout="column" fxLayoutGap="20px">
-        <mat-stepper orientation="horizontal" linear="true" *ngIf="algemeenFormGroup">
+        <mat-stepper orientation="horizontal" [linear]="!algemeenFormGroup.valid" *ngIf="algemeenFormGroup">
             <mat-step [stepControl]="algemeenFormGroup">
                 <ng-template matStepLabel>{{"gegevens.algemeen" | translate}}</ng-template>
                 <form [formGroup]="algemeenFormGroup" fxLayout="column">
@@ -170,8 +170,7 @@
                     </form>
                 </ng-template>
             </mat-step>
-
-            <mat-step [stepControl]="userEventListenersFormGroup">
+            <mat-step [stepControl]="userEventListenersFormGroup" [hasError]="userEventListenersFormGroup.invalid">
                 <ng-template matStepLabel>{{"gegevens.acties" | translate}}</ng-template>
                 <ng-template matStepContent>
                     <form [formGroup]="userEventListenersFormGroup" fxLayout="column">
@@ -203,8 +202,7 @@
                     </form>
                 </ng-template>
             </mat-step>
-
-            <mat-step [stepControl]="mailtemplateKoppelingenFormGroup">
+            <mat-step [stepControl]="mailtemplateKoppelingenFormGroup" [hasError]="mailtemplateKoppelingenFormGroup.invalid">
                 <ng-template matStepLabel>{{"gegevens.mailtemplate.koppelingen" | translate}}</ng-template>
                 <ng-template matStepContent>
                     <form [formGroup]="mailtemplateKoppelingenFormGroup" fxLayout="column">
@@ -237,8 +235,7 @@
                     </form>
                 </ng-template>
             </mat-step>
-
-            <mat-step [stepControl]="zaakbeeindigFormGroup">
+            <mat-step [stepControl]="zaakbeeindigFormGroup" [hasError]="zaakbeeindigFormGroup.invalid">
                 <ng-template matStepLabel>{{"gegevens.beeindiging" | translate}}</ng-template>
                 <ng-template matStepContent>
                     <form [formGroup]="zaakbeeindigFormGroup" fxLayout="column">

--- a/src/main/app/src/app/shared/material-form-builder/form-components/autocomplete/autocomplete-validators.ts
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/autocomplete/autocomplete-validators.ts
@@ -47,7 +47,8 @@ export class AutocompleteValidators {
             } else if (object1.hasOwnProperty('name')) {
                 return object1.name === object2.name;
             }
-            return object1 === object2;
+
+            return JSON.stringify(object1) === JSON.stringify(object2);
         }
         return false;
     }

--- a/src/main/app/src/app/shared/material-form-builder/form-components/autocomplete/autocomplete-validators.ts
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/autocomplete/autocomplete-validators.ts
@@ -40,6 +40,10 @@ export class AutocompleteValidators {
         if (object1 && object2) {
             if (object1.hasOwnProperty('key')) {
                 return object1.key === object2.key;
+            } else if (object1.hasOwnProperty('uuid')) {
+                return object1.uuid === object2.uuid;
+            } else if (object1.hasOwnProperty('identificatie')) {
+                return object1.identificatie === object2.identificatie;
             } else if (object1.hasOwnProperty('id')) {
                 return object1.id === object2.id;
             } else if (object1.hasOwnProperty('naam')) {
@@ -48,7 +52,7 @@ export class AutocompleteValidators {
                 return object1.name === object2.name;
             }
 
-            return JSON.stringify(object1) === JSON.stringify(object2);
+            throw new Error('Er is geen property aanwezig om te kunnen vergelijken');
         }
         return false;
     }

--- a/src/main/java/net/atos/client/klanten/KlantenClient.java
+++ b/src/main/java/net/atos/client/klanten/KlantenClient.java
@@ -28,10 +28,10 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterProviders;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 import net.atos.client.klanten.exception.RuntimeExceptionMapper;
+import net.atos.client.klanten.model.AuditTrail;
+import net.atos.client.klanten.model.Klant;
+import net.atos.client.klanten.model.KlantList200Response;
 import net.atos.client.klanten.model.KlantListParameters;
-import net.atos.client.klanten.model.generated.AuditTrail;
-import net.atos.client.klanten.model.generated.Klant;
-import net.atos.client.klanten.model.generated.KlantList200Response;
 import net.atos.client.klanten.util.KlantenClientHeadersFactory;
 import net.atos.client.kvk.exception.KvKClientNoResultExceptionMapper;
 

--- a/src/main/java/net/atos/client/klanten/KlantenClientService.java
+++ b/src/main/java/net/atos/client/klanten/KlantenClientService.java
@@ -13,9 +13,9 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
+import net.atos.client.klanten.model.Klant;
+import net.atos.client.klanten.model.KlantList200Response;
 import net.atos.client.klanten.model.KlantListParameters;
-import net.atos.client.klanten.model.generated.Klant;
-import net.atos.client.klanten.model.generated.KlantList200Response;
 import net.atos.zac.configuratie.ConfiguratieService;
 
 @ApplicationScoped

--- a/src/main/java/net/atos/client/klanten/model/AuditTrail.java
+++ b/src/main/java/net/atos/client/klanten/model/AuditTrail.java
@@ -15,7 +15,7 @@
  * Do not edit the class manually.
  */
 
-package net.atos.client.klanten.model.generated;
+package net.atos.client.klanten.model;
 
 import java.lang.reflect.Type;
 import java.net.URI;

--- a/src/main/java/net/atos/client/klanten/model/FieldValidationError.java
+++ b/src/main/java/net/atos/client/klanten/model/FieldValidationError.java
@@ -15,33 +15,89 @@
  * Do not edit the class manually.
  */
 
-package net.atos.client.klanten.model.generated;
+package net.atos.client.klanten.model;
+
 
 import javax.json.bind.annotation.JsonbProperty;
 
 
-public class SubjectIdentificatieNatuurlijkPersoon {
-
-    @JsonbProperty("subjectIdentificatie")
-    private NatuurlijkPersoon subjectIdentificatie;
+public class FieldValidationError {
 
     /**
-     * Get subjectIdentificatie
-     * @return subjectIdentificatie
+     * Naam van het veld met ongeldige gegevens
      **/
-    public NatuurlijkPersoon getSubjectIdentificatie() {
-        return subjectIdentificatie;
+    @JsonbProperty("name")
+    private String name;
+
+    /**
+     * Systeemcode die het type fout aangeeft
+     **/
+    @JsonbProperty("code")
+    private String code;
+
+    /**
+     * Uitleg wat er precies fout is met de gegevens
+     **/
+    @JsonbProperty("reason")
+    private String reason;
+
+    /**
+     * Naam van het veld met ongeldige gegevens
+     * @return name
+     **/
+    public String getName() {
+        return name;
     }
 
     /**
-     * Set subjectIdentificatie
+     * Set name
      **/
-    public void setSubjectIdentificatie(NatuurlijkPersoon subjectIdentificatie) {
-        this.subjectIdentificatie = subjectIdentificatie;
+    public void setName(String name) {
+        this.name = name;
     }
 
-    public SubjectIdentificatieNatuurlijkPersoon subjectIdentificatie(NatuurlijkPersoon subjectIdentificatie) {
-        this.subjectIdentificatie = subjectIdentificatie;
+    public FieldValidationError name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Systeemcode die het type fout aangeeft
+     * @return code
+     **/
+    public String getCode() {
+        return code;
+    }
+
+    /**
+     * Set code
+     **/
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public FieldValidationError code(String code) {
+        this.code = code;
+        return this;
+    }
+
+    /**
+     * Uitleg wat er precies fout is met de gegevens
+     * @return reason
+     **/
+    public String getReason() {
+        return reason;
+    }
+
+    /**
+     * Set reason
+     **/
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+
+    public FieldValidationError reason(String reason) {
+        this.reason = reason;
         return this;
     }
 
@@ -52,9 +108,11 @@ public class SubjectIdentificatieNatuurlijkPersoon {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("class SubjectIdentificatieNatuurlijkPersoon {\n");
+        sb.append("class FieldValidationError {\n");
 
-        sb.append("    subjectIdentificatie: ").append(toIndentedString(subjectIdentificatie)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    reason: ").append(toIndentedString(reason)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/src/main/java/net/atos/client/klanten/model/Fout.java
+++ b/src/main/java/net/atos/client/klanten/model/Fout.java
@@ -15,7 +15,7 @@
  * Do not edit the class manually.
  */
 
-package net.atos.client.klanten.model.generated;
+package net.atos.client.klanten.model;
 
 
 import javax.json.bind.annotation.JsonbProperty;

--- a/src/main/java/net/atos/client/klanten/model/Klant.java
+++ b/src/main/java/net/atos/client/klanten/model/Klant.java
@@ -15,7 +15,7 @@
  * Do not edit the class manually.
  */
 
-package net.atos.client.klanten.model.generated;
+package net.atos.client.klanten.model;
 
 import java.lang.reflect.Type;
 import java.net.URI;

--- a/src/main/java/net/atos/client/klanten/model/KlantAdres.java
+++ b/src/main/java/net/atos/client/klanten/model/KlantAdres.java
@@ -15,7 +15,7 @@
  * Do not edit the class manually.
  */
 
-package net.atos.client.klanten.model.generated;
+package net.atos.client.klanten.model;
 
 
 import javax.json.bind.annotation.JsonbProperty;

--- a/src/main/java/net/atos/client/klanten/model/KlantList200Response.java
+++ b/src/main/java/net/atos/client/klanten/model/KlantList200Response.java
@@ -15,7 +15,7 @@
  * Do not edit the class manually.
  */
 
-package net.atos.client.klanten.model.generated;
+package net.atos.client.klanten.model;
 
 import java.net.URI;
 import java.util.ArrayList;

--- a/src/main/java/net/atos/client/klanten/model/NatuurlijkPersoon.java
+++ b/src/main/java/net/atos/client/klanten/model/NatuurlijkPersoon.java
@@ -15,63 +15,46 @@
  * Do not edit the class manually.
  */
 
-package net.atos.client.klanten.model.generated;
+package net.atos.client.klanten.model;
 
+import java.net.URI;
 
+import javax.json.bind.annotation.JsonbCreator;
 import javax.json.bind.annotation.JsonbProperty;
 
 
-public class Wijzigingen {
+public class NatuurlijkPersoon extends Klant {
 
-    /**
-     * Volledige JSON body van het object zoals dat bestond voordat de actie heeft plaatsgevonden.
-     **/
-    @JsonbProperty("oud")
-    private Object oud;
+    @JsonbProperty("subjectIdentificatie")
+    private NatuurlijkPersoon subjectIdentificatie;
 
-    /**
-     * Volledige JSON body van het object na de actie.
-     **/
-    @JsonbProperty("nieuw")
-    private Object nieuw;
+    public NatuurlijkPersoon() {
+    }
 
-    /**
-     * Volledige JSON body van het object zoals dat bestond voordat de actie heeft plaatsgevonden.
-     * @return oud
-     **/
-    public Object getOud() {
-        return oud;
+    @JsonbCreator
+    public NatuurlijkPersoon(
+            @JsonbProperty(value = "url", nillable = true) URI url
+    ) {
+        this.url = url;
     }
 
     /**
-     * Set oud
+     * Get subjectIdentificatie
+     * @return subjectIdentificatie
      **/
-    public void setOud(Object oud) {
-        this.oud = oud;
-    }
-
-    public Wijzigingen oud(Object oud) {
-        this.oud = oud;
-        return this;
+    public NatuurlijkPersoon getSubjectIdentificatie() {
+        return subjectIdentificatie;
     }
 
     /**
-     * Volledige JSON body van het object na de actie.
-     * @return nieuw
+     * Set subjectIdentificatie
      **/
-    public Object getNieuw() {
-        return nieuw;
+    public void setSubjectIdentificatie(NatuurlijkPersoon subjectIdentificatie) {
+        this.subjectIdentificatie = subjectIdentificatie;
     }
 
-    /**
-     * Set nieuw
-     **/
-    public void setNieuw(Object nieuw) {
-        this.nieuw = nieuw;
-    }
-
-    public Wijzigingen nieuw(Object nieuw) {
-        this.nieuw = nieuw;
+    public NatuurlijkPersoon subjectIdentificatie(NatuurlijkPersoon subjectIdentificatie) {
+        this.subjectIdentificatie = subjectIdentificatie;
         return this;
     }
 
@@ -82,10 +65,9 @@ public class Wijzigingen {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("class Wijzigingen {\n");
-
-        sb.append("    oud: ").append(toIndentedString(oud)).append("\n");
-        sb.append("    nieuw: ").append(toIndentedString(nieuw)).append("\n");
+        sb.append("class NatuurlijkPersoon {\n");
+        sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+        sb.append("    subjectIdentificatie: ").append(toIndentedString(subjectIdentificatie)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/src/main/java/net/atos/client/klanten/model/NietNatuurlijkPersoon.java
+++ b/src/main/java/net/atos/client/klanten/model/NietNatuurlijkPersoon.java
@@ -15,15 +15,28 @@
  * Do not edit the class manually.
  */
 
-package net.atos.client.klanten.model.generated;
+package net.atos.client.klanten.model;
 
+import java.net.URI;
+
+import javax.json.bind.annotation.JsonbCreator;
 import javax.json.bind.annotation.JsonbProperty;
 
 
-public class SubjectIdentificatieNietNatuurlijkPersoon {
+public class NietNatuurlijkPersoon extends Klant {
 
     @JsonbProperty("subjectIdentificatie")
     private NietNatuurlijkPersoon subjectIdentificatie;
+
+    public NietNatuurlijkPersoon() {
+    }
+
+    @JsonbCreator
+    public NietNatuurlijkPersoon(
+            @JsonbProperty(value = "url", nillable = true) URI url
+    ) {
+        this.url = url;
+    }
 
     /**
      * Get subjectIdentificatie
@@ -40,7 +53,7 @@ public class SubjectIdentificatieNietNatuurlijkPersoon {
         this.subjectIdentificatie = subjectIdentificatie;
     }
 
-    public SubjectIdentificatieNietNatuurlijkPersoon subjectIdentificatie(NietNatuurlijkPersoon subjectIdentificatie) {
+    public NietNatuurlijkPersoon subjectIdentificatie(NietNatuurlijkPersoon subjectIdentificatie) {
         this.subjectIdentificatie = subjectIdentificatie;
         return this;
     }
@@ -52,8 +65,8 @@ public class SubjectIdentificatieNietNatuurlijkPersoon {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("class SubjectIdentificatieNietNatuurlijkPersoon {\n");
-
+        sb.append("class NietNatuurlijkPersoon {\n");
+        sb.append("    ").append(toIndentedString(super.toString())).append("\n");
         sb.append("    subjectIdentificatie: ").append(toIndentedString(subjectIdentificatie)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/src/main/java/net/atos/client/klanten/model/SubVerblijfBuitenland.java
+++ b/src/main/java/net/atos/client/klanten/model/SubVerblijfBuitenland.java
@@ -15,7 +15,7 @@
  * Do not edit the class manually.
  */
 
-package net.atos.client.klanten.model.generated;
+package net.atos.client.klanten.model;
 
 
 import javax.json.bind.annotation.JsonbProperty;

--- a/src/main/java/net/atos/client/klanten/model/SubjectIdentificatieNatuurlijkPersoon.java
+++ b/src/main/java/net/atos/client/klanten/model/SubjectIdentificatieNatuurlijkPersoon.java
@@ -15,32 +15,32 @@
  * Do not edit the class manually.
  */
 
-package net.atos.client.klanten.model.generated;
+package net.atos.client.klanten.model;
 
 import javax.json.bind.annotation.JsonbProperty;
 
 
-public class SubjectIdentificatieVestiging {
+public class SubjectIdentificatieNatuurlijkPersoon {
 
     @JsonbProperty("subjectIdentificatie")
-    private Vestiging subjectIdentificatie;
+    private NatuurlijkPersoon subjectIdentificatie;
 
     /**
      * Get subjectIdentificatie
      * @return subjectIdentificatie
      **/
-    public Vestiging getSubjectIdentificatie() {
+    public NatuurlijkPersoon getSubjectIdentificatie() {
         return subjectIdentificatie;
     }
 
     /**
      * Set subjectIdentificatie
      **/
-    public void setSubjectIdentificatie(Vestiging subjectIdentificatie) {
+    public void setSubjectIdentificatie(NatuurlijkPersoon subjectIdentificatie) {
         this.subjectIdentificatie = subjectIdentificatie;
     }
 
-    public SubjectIdentificatieVestiging subjectIdentificatie(Vestiging subjectIdentificatie) {
+    public SubjectIdentificatieNatuurlijkPersoon subjectIdentificatie(NatuurlijkPersoon subjectIdentificatie) {
         this.subjectIdentificatie = subjectIdentificatie;
         return this;
     }
@@ -52,7 +52,7 @@ public class SubjectIdentificatieVestiging {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("class SubjectIdentificatieVestiging {\n");
+        sb.append("class SubjectIdentificatieNatuurlijkPersoon {\n");
 
         sb.append("    subjectIdentificatie: ").append(toIndentedString(subjectIdentificatie)).append("\n");
         sb.append("}");

--- a/src/main/java/net/atos/client/klanten/model/SubjectIdentificatieNietNatuurlijkPersoon.java
+++ b/src/main/java/net/atos/client/klanten/model/SubjectIdentificatieNietNatuurlijkPersoon.java
@@ -15,89 +15,33 @@
  * Do not edit the class manually.
  */
 
-package net.atos.client.klanten.model.generated;
-
+package net.atos.client.klanten.model;
 
 import javax.json.bind.annotation.JsonbProperty;
 
 
-public class FieldValidationError {
+public class SubjectIdentificatieNietNatuurlijkPersoon {
+
+    @JsonbProperty("subjectIdentificatie")
+    private NietNatuurlijkPersoon subjectIdentificatie;
 
     /**
-     * Naam van het veld met ongeldige gegevens
+     * Get subjectIdentificatie
+     * @return subjectIdentificatie
      **/
-    @JsonbProperty("name")
-    private String name;
-
-    /**
-     * Systeemcode die het type fout aangeeft
-     **/
-    @JsonbProperty("code")
-    private String code;
-
-    /**
-     * Uitleg wat er precies fout is met de gegevens
-     **/
-    @JsonbProperty("reason")
-    private String reason;
-
-    /**
-     * Naam van het veld met ongeldige gegevens
-     * @return name
-     **/
-    public String getName() {
-        return name;
+    public NietNatuurlijkPersoon getSubjectIdentificatie() {
+        return subjectIdentificatie;
     }
 
     /**
-     * Set name
+     * Set subjectIdentificatie
      **/
-    public void setName(String name) {
-        this.name = name;
+    public void setSubjectIdentificatie(NietNatuurlijkPersoon subjectIdentificatie) {
+        this.subjectIdentificatie = subjectIdentificatie;
     }
 
-    public FieldValidationError name(String name) {
-        this.name = name;
-        return this;
-    }
-
-    /**
-     * Systeemcode die het type fout aangeeft
-     * @return code
-     **/
-    public String getCode() {
-        return code;
-    }
-
-    /**
-     * Set code
-     **/
-    public void setCode(String code) {
-        this.code = code;
-    }
-
-    public FieldValidationError code(String code) {
-        this.code = code;
-        return this;
-    }
-
-    /**
-     * Uitleg wat er precies fout is met de gegevens
-     * @return reason
-     **/
-    public String getReason() {
-        return reason;
-    }
-
-    /**
-     * Set reason
-     **/
-    public void setReason(String reason) {
-        this.reason = reason;
-    }
-
-    public FieldValidationError reason(String reason) {
-        this.reason = reason;
+    public SubjectIdentificatieNietNatuurlijkPersoon subjectIdentificatie(NietNatuurlijkPersoon subjectIdentificatie) {
+        this.subjectIdentificatie = subjectIdentificatie;
         return this;
     }
 
@@ -108,11 +52,9 @@ public class FieldValidationError {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("class FieldValidationError {\n");
+        sb.append("class SubjectIdentificatieNietNatuurlijkPersoon {\n");
 
-        sb.append("    name: ").append(toIndentedString(name)).append("\n");
-        sb.append("    code: ").append(toIndentedString(code)).append("\n");
-        sb.append("    reason: ").append(toIndentedString(reason)).append("\n");
+        sb.append("    subjectIdentificatie: ").append(toIndentedString(subjectIdentificatie)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/src/main/java/net/atos/client/klanten/model/SubjectIdentificatieVestiging.java
+++ b/src/main/java/net/atos/client/klanten/model/SubjectIdentificatieVestiging.java
@@ -15,45 +15,32 @@
  * Do not edit the class manually.
  */
 
-package net.atos.client.klanten.model.generated;
+package net.atos.client.klanten.model;
 
-import java.net.URI;
-
-import javax.json.bind.annotation.JsonbCreator;
 import javax.json.bind.annotation.JsonbProperty;
 
 
-public class NietNatuurlijkPersoon extends Klant {
+public class SubjectIdentificatieVestiging {
 
     @JsonbProperty("subjectIdentificatie")
-    private NietNatuurlijkPersoon subjectIdentificatie;
-
-    public NietNatuurlijkPersoon() {
-    }
-
-    @JsonbCreator
-    public NietNatuurlijkPersoon(
-            @JsonbProperty(value = "url", nillable = true) URI url
-    ) {
-        this.url = url;
-    }
+    private Vestiging subjectIdentificatie;
 
     /**
      * Get subjectIdentificatie
      * @return subjectIdentificatie
      **/
-    public NietNatuurlijkPersoon getSubjectIdentificatie() {
+    public Vestiging getSubjectIdentificatie() {
         return subjectIdentificatie;
     }
 
     /**
      * Set subjectIdentificatie
      **/
-    public void setSubjectIdentificatie(NietNatuurlijkPersoon subjectIdentificatie) {
+    public void setSubjectIdentificatie(Vestiging subjectIdentificatie) {
         this.subjectIdentificatie = subjectIdentificatie;
     }
 
-    public NietNatuurlijkPersoon subjectIdentificatie(NietNatuurlijkPersoon subjectIdentificatie) {
+    public SubjectIdentificatieVestiging subjectIdentificatie(Vestiging subjectIdentificatie) {
         this.subjectIdentificatie = subjectIdentificatie;
         return this;
     }
@@ -65,8 +52,8 @@ public class NietNatuurlijkPersoon extends Klant {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("class NietNatuurlijkPersoon {\n");
-        sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+        sb.append("class SubjectIdentificatieVestiging {\n");
+
         sb.append("    subjectIdentificatie: ").append(toIndentedString(subjectIdentificatie)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/src/main/java/net/atos/client/klanten/model/ValidatieFout.java
+++ b/src/main/java/net/atos/client/klanten/model/ValidatieFout.java
@@ -15,7 +15,7 @@
  * Do not edit the class manually.
  */
 
-package net.atos.client.klanten.model.generated;
+package net.atos.client.klanten.model;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/net/atos/client/klanten/model/VerblijfsAdres.java
+++ b/src/main/java/net/atos/client/klanten/model/VerblijfsAdres.java
@@ -15,7 +15,7 @@
  * Do not edit the class manually.
  */
 
-package net.atos.client.klanten.model.generated;
+package net.atos.client.klanten.model;
 
 
 import javax.json.bind.annotation.JsonbProperty;

--- a/src/main/java/net/atos/client/klanten/model/Vestiging.java
+++ b/src/main/java/net/atos/client/klanten/model/Vestiging.java
@@ -15,7 +15,7 @@
  * Do not edit the class manually.
  */
 
-package net.atos.client.klanten.model.generated;
+package net.atos.client.klanten.model;
 
 import java.net.URI;
 
@@ -23,16 +23,16 @@ import javax.json.bind.annotation.JsonbCreator;
 import javax.json.bind.annotation.JsonbProperty;
 
 
-public class NatuurlijkPersoon extends Klant {
+public class Vestiging extends Klant {
 
     @JsonbProperty("subjectIdentificatie")
-    private NatuurlijkPersoon subjectIdentificatie;
+    private Vestiging subjectIdentificatie;
 
-    public NatuurlijkPersoon() {
+    public Vestiging() {
     }
 
     @JsonbCreator
-    public NatuurlijkPersoon(
+    public Vestiging(
             @JsonbProperty(value = "url", nillable = true) URI url
     ) {
         this.url = url;
@@ -42,18 +42,18 @@ public class NatuurlijkPersoon extends Klant {
      * Get subjectIdentificatie
      * @return subjectIdentificatie
      **/
-    public NatuurlijkPersoon getSubjectIdentificatie() {
+    public Vestiging getSubjectIdentificatie() {
         return subjectIdentificatie;
     }
 
     /**
      * Set subjectIdentificatie
      **/
-    public void setSubjectIdentificatie(NatuurlijkPersoon subjectIdentificatie) {
+    public void setSubjectIdentificatie(Vestiging subjectIdentificatie) {
         this.subjectIdentificatie = subjectIdentificatie;
     }
 
-    public NatuurlijkPersoon subjectIdentificatie(NatuurlijkPersoon subjectIdentificatie) {
+    public Vestiging subjectIdentificatie(Vestiging subjectIdentificatie) {
         this.subjectIdentificatie = subjectIdentificatie;
         return this;
     }
@@ -65,7 +65,7 @@ public class NatuurlijkPersoon extends Klant {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("class NatuurlijkPersoon {\n");
+        sb.append("class Vestiging {\n");
         sb.append("    ").append(toIndentedString(super.toString())).append("\n");
         sb.append("    subjectIdentificatie: ").append(toIndentedString(subjectIdentificatie)).append("\n");
         sb.append("}");

--- a/src/main/java/net/atos/client/klanten/model/Wijzigingen.java
+++ b/src/main/java/net/atos/client/klanten/model/Wijzigingen.java
@@ -15,46 +15,63 @@
  * Do not edit the class manually.
  */
 
-package net.atos.client.klanten.model.generated;
+package net.atos.client.klanten.model;
 
-import java.net.URI;
 
 import javax.json.bind.annotation.JsonbProperty;
-import javax.json.bind.annotation.JsonbCreator;
 
 
-public class Vestiging extends Klant {
+public class Wijzigingen {
 
-    @JsonbProperty("subjectIdentificatie")
-    private Vestiging subjectIdentificatie;
+    /**
+     * Volledige JSON body van het object zoals dat bestond voordat de actie heeft plaatsgevonden.
+     **/
+    @JsonbProperty("oud")
+    private Object oud;
 
-    public Vestiging() {
-    }
+    /**
+     * Volledige JSON body van het object na de actie.
+     **/
+    @JsonbProperty("nieuw")
+    private Object nieuw;
 
-    @JsonbCreator
-    public Vestiging(
-            @JsonbProperty(value = "url", nillable = true) URI url
-    ) {
-        this.url = url;
+    /**
+     * Volledige JSON body van het object zoals dat bestond voordat de actie heeft plaatsgevonden.
+     * @return oud
+     **/
+    public Object getOud() {
+        return oud;
     }
 
     /**
-     * Get subjectIdentificatie
-     * @return subjectIdentificatie
+     * Set oud
      **/
-    public Vestiging getSubjectIdentificatie() {
-        return subjectIdentificatie;
+    public void setOud(Object oud) {
+        this.oud = oud;
+    }
+
+    public Wijzigingen oud(Object oud) {
+        this.oud = oud;
+        return this;
     }
 
     /**
-     * Set subjectIdentificatie
+     * Volledige JSON body van het object na de actie.
+     * @return nieuw
      **/
-    public void setSubjectIdentificatie(Vestiging subjectIdentificatie) {
-        this.subjectIdentificatie = subjectIdentificatie;
+    public Object getNieuw() {
+        return nieuw;
     }
 
-    public Vestiging subjectIdentificatie(Vestiging subjectIdentificatie) {
-        this.subjectIdentificatie = subjectIdentificatie;
+    /**
+     * Set nieuw
+     **/
+    public void setNieuw(Object nieuw) {
+        this.nieuw = nieuw;
+    }
+
+    public Wijzigingen nieuw(Object nieuw) {
+        this.nieuw = nieuw;
         return this;
     }
 
@@ -65,9 +82,10 @@ public class Vestiging extends Klant {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("class Vestiging {\n");
-        sb.append("    ").append(toIndentedString(super.toString())).append("\n");
-        sb.append("    subjectIdentificatie: ").append(toIndentedString(subjectIdentificatie)).append("\n");
+        sb.append("class Wijzigingen {\n");
+
+        sb.append("    oud: ").append(toIndentedString(oud)).append("\n");
+        sb.append("    nieuw: ").append(toIndentedString(nieuw)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/src/main/java/net/atos/zac/app/klanten/KlantenRESTService.java
+++ b/src/main/java/net/atos/zac/app/klanten/KlantenRESTService.java
@@ -31,7 +31,7 @@ import net.atos.client.brp.model.IngeschrevenPersoonHal;
 import net.atos.client.brp.model.IngeschrevenPersoonHalCollectie;
 import net.atos.client.brp.model.ListPersonenParameters;
 import net.atos.client.klanten.KlantenClientService;
-import net.atos.client.klanten.model.generated.Klant;
+import net.atos.client.klanten.model.Klant;
 import net.atos.client.kvk.KVKClientService;
 import net.atos.client.kvk.model.KVKZoekenParameters;
 import net.atos.client.kvk.zoeken.model.Resultaat;

--- a/src/main/java/net/atos/zac/mailtemplates/MailTemplateHelper.java
+++ b/src/main/java/net/atos/zac/mailtemplates/MailTemplateHelper.java
@@ -24,6 +24,7 @@ import static net.atos.zac.mailtemplates.model.MailTemplateVariabelen.ZAAK_TYPE;
 import static net.atos.zac.mailtemplates.model.MailTemplateVariabelen.ZAAK_URL;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
+import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -65,6 +66,8 @@ public class MailTemplateHelper {
 
     public static final Pattern PTAGS = Pattern.compile("</?p>", Pattern.CASE_INSENSITIVE);
 
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy");
+
     @Inject
     private ConfiguratieService configuratieService;
 
@@ -105,10 +108,14 @@ public class MailTemplateHelper {
 
             resolvedTekst = replaceVariabele(resolvedTekst, ZAAK_OMSCHRIJVING, zaak.getOmschrijving());
             resolvedTekst = replaceVariabele(resolvedTekst, ZAAK_TOELICHTING, zaak.getToelichting());
-            resolvedTekst = replaceVariabele(resolvedTekst, ZAAK_REGISTRATIEDATUM, zaak.getRegistratiedatum());
-            resolvedTekst = replaceVariabele(resolvedTekst, ZAAK_STARTDATUM, zaak.getStartdatum());
-            resolvedTekst = replaceVariabele(resolvedTekst, ZAAK_STREEFDATUM, zaak.getEinddatumGepland());
-            resolvedTekst = replaceVariabele(resolvedTekst, ZAAK_FATALEDATUM, zaak.getUiterlijkeEinddatumAfdoening());
+            resolvedTekst = replaceVariabele(resolvedTekst, ZAAK_REGISTRATIEDATUM,
+                                             zaak.getRegistratiedatum().format(DATE_FORMATTER));
+            resolvedTekst = replaceVariabele(resolvedTekst, ZAAK_STARTDATUM,
+                                             zaak.getStartdatum().format(DATE_FORMATTER));
+            resolvedTekst = replaceVariabele(resolvedTekst, ZAAK_STREEFDATUM,
+                                             zaak.getEinddatumGepland().format(DATE_FORMATTER));
+            resolvedTekst = replaceVariabele(resolvedTekst, ZAAK_FATALEDATUM,
+                                             zaak.getUiterlijkeEinddatumAfdoening().format(DATE_FORMATTER));
 
             if (resolvedTekst.contains(ZAAK_STATUS.getVariabele())) {
                 resolvedTekst = replaceVariabele(resolvedTekst, ZAAK_STATUS,


### PR DESCRIPTION
De opties van de `AutoCompleteFormField` worden opnieuw geinitialiseerd na het selecteren van een option. Dit lijkt niet het geval te zijn voor de `SelectFormField`.

Het probleem zat in de `equals`-methode van `AutocompleteValidators`. Het direct checken of twee objecten hetzelfde zijn met `===` werkt alleen als de reference naar het object hetzelfde is, wat vaak niet het geval is in checks die we in de front-end doen. In deze gevallen willen we wel `true` retourneren uit deze methode, zo lang alle keys en values maar overeenkomen.

~De aanpassing die ik heb toegevoegd heeft ook nog wat haken en ogen. De beste oplossing zou de `.isEqual` methode van LoDash zijn. Die lib hebben we (nog) niet in ZAC, dus voor nu heb ik een (verkapte) herimplementatie toegevoegd. Zo controleert hij bijvoorbeeld maar obv een van de objecten, dus keys die in object2 wel aanwezig zijn maar in object1 niet worden gewoon overgeslagen.~ De aanpassing die ik heb toegevoegd controleert alleen dat de string-representatie van alle keys en values overeenkomen. Dat is niet helemaal hetzelfde als een complete equality-operator zoals de `isEqual`-methode van LoDash, maar dit is voor ons gebruik voldoende.