### PR TITLE
zaakafhandelcomponent-1965 autorisatie aanpassingen

### DIFF
--- a/src/main/app/src/app/admin/parameter-edit/parameter-edit.component.ts
+++ b/src/main/app/src/app/admin/parameter-edit/parameter-edit.component.ts
@@ -88,7 +88,7 @@ export class ParameterEditComponent extends AdminComponent implements OnInit {
                 adminService.listCaseDefinitions(),
                 adminService.listFormulierDefinities(),
                 referentieTabelService.listReferentieTabellen(),
-                referentieTabelService.readDomeinen(),
+                referentieTabelService.listDomeinen(),
                 identityService.listGroups(),
                 identityService.listUsers(),
                 this.adminService.listZaakbeeindigRedenen(),

--- a/src/main/app/src/app/admin/referentie-tabel.service.ts
+++ b/src/main/app/src/app/admin/referentie-tabel.service.ts
@@ -50,7 +50,7 @@ export class ReferentieTabelService {
         );
     }
 
-    readDomeinen(): Observable<string[]> {
+    listDomeinen(): Observable<string[]> {
         return this.http.get<string[]>(`${this.basepath}/domein`).pipe(
             catchError(err => this.foutAfhandelingService.foutAfhandelen(err))
         );

--- a/src/main/java/net/atos/client/zgw/zrc/ZRCClientService.java
+++ b/src/main/java/net/atos/client/zgw/zrc/ZRCClientService.java
@@ -314,10 +314,16 @@ public class ZRCClientService {
         return zrcClient.zaakinformatieobjectList(filter);
     }
 
+    public List<ZaakInformatieobject> listZaakinformatieobjecten(final Zaak zaak) {
+        final ZaakInformatieobjectListParameters parameters = new ZaakInformatieobjectListParameters();
+        parameters.setInformatieobject(zaak.getUrl());
+        return listZaakinformatieobjecten(zaak);
+    }
+
     public List<ZaakInformatieobject> listZaakinformatieobjecten(final EnkelvoudigInformatieobject informatieobject) {
         final ZaakInformatieobjectListParameters parameters = new ZaakInformatieobjectListParameters();
         parameters.setInformatieobject(informatieobject.getUrl());
-        return listZaakinformatieobjecten(parameters);
+        return listZaakinformatieobjecten(informatieobject);
     }
 
     /**
@@ -426,10 +432,6 @@ public class ZRCClientService {
 
     public URI createUrlExternToZaak(final UUID zaakUUID) {
         return UriBuilder.fromUri(zgwApiUrlExtern).path(ZRCClient.class).path(ZRCClient.class, "zaakRead").build(zaakUUID);
-    }
-
-    public URI createUrlZaak(final UUID zaakUUID) {
-        return UriBuilder.fromUri(getZgwApiClientMpRestUrl).path(ZRCClient.class).path(ZRCClient.class, "zaakRead").build(zaakUUID);
     }
 
     public boolean heeftOpenDeelzaken(final Zaak zaak) {

--- a/src/main/java/net/atos/zac/app/admin/ReferentieTabelRESTService.java
+++ b/src/main/java/net/atos/zac/app/admin/ReferentieTabelRESTService.java
@@ -103,7 +103,7 @@ public class ReferentieTabelRESTService {
 
     @GET
     @Path("domein")
-    public List<String> readDomeinen() {
+    public List<String> listDomeinen() {
         assertPolicy(policyService.readOverigeRechten().getBeheren());
         return restReferentieWaardeConverter.convert(
                 referentieTabelService.readReferentieTabel(DOMEIN.name()).getWaarden());

--- a/src/main/java/net/atos/zac/app/admin/ZaakafhandelParametersRESTService.java
+++ b/src/main/java/net/atos/zac/app/admin/ZaakafhandelParametersRESTService.java
@@ -154,7 +154,6 @@ public class ZaakafhandelParametersRESTService {
             zaakafhandelParameters = zaakafhandelParameterBeheerService.createZaakafhandelParameters(zaakafhandelParameters);
         } else {
             zaakafhandelParameters = zaakafhandelParameterBeheerService.updateZaakafhandelParameters(zaakafhandelParameters);
-            zaakafhandelParameterService.cacheRemoveZaakafhandelParameters(zaakafhandelParameters.getZaakTypeUUID());
         }
         return zaakafhandelParametersConverter.convertZaakafhandelParameters(zaakafhandelParameters, true);
     }

--- a/src/main/java/net/atos/zac/app/informatieobjecten/InformatieObjectenRESTService.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/InformatieObjectenRESTService.java
@@ -46,11 +46,9 @@ import net.atos.client.zgw.drc.model.EnkelvoudigInformatieobjectWithInhoud;
 import net.atos.client.zgw.drc.model.EnkelvoudigInformatieobjectWithInhoudAndLock;
 import net.atos.client.zgw.shared.ZGWApiService;
 import net.atos.client.zgw.shared.model.audit.AuditTrailRegel;
-import net.atos.client.zgw.shared.util.URIUtil;
 import net.atos.client.zgw.zrc.ZRCClientService;
 import net.atos.client.zgw.zrc.model.Zaak;
 import net.atos.client.zgw.zrc.model.ZaakInformatieobject;
-import net.atos.client.zgw.zrc.model.ZaakInformatieobjectListParameters;
 import net.atos.client.zgw.ztc.ZTCClientService;
 import net.atos.client.zgw.ztc.model.Besluittype;
 import net.atos.client.zgw.ztc.model.Informatieobjecttype;
@@ -253,7 +251,7 @@ public class InformatieObjectenRESTService {
         if (taakObject) {
             final Task task = takenService.readOpenTask(documentReferentieId);
             final List<UUID> taakdocumenten = taakVariabelenService.readTaakdocumenten(task);
-            taakdocumenten.add(URIUtil.parseUUIDFromResourceURI(zaakInformatieobject.getInformatieobject()));
+            taakdocumenten.add(UriUtil.uuidFromURI(zaakInformatieobject.getInformatieobject()));
             taakVariabelenService.setTaakdocumenten(task, taakdocumenten);
         }
         return informatieobjectConverter.convertToREST(zaakInformatieobject);
@@ -529,24 +527,16 @@ public class InformatieObjectenRESTService {
     }
 
     private List<RESTEnkelvoudigInformatieobject> listEnkelvoudigInformatieobjectenVoorZaak(final Zaak zaak) {
-        final ZaakInformatieobjectListParameters parameters = new ZaakInformatieobjectListParameters();
-        parameters.setZaak(zaak.getUrl());
-        final List<ZaakInformatieobject> zaakInformatieobjecten = zrcClientService.listZaakinformatieobjecten(
-                parameters);
-        return informatieobjectConverter.convertToREST(zaakInformatieobjecten);
+        return informatieobjectConverter.convertToREST(zrcClientService.listZaakinformatieobjecten(zaak));
     }
 
     private List<RESTGekoppeldeZaakEnkelvoudigInformatieObject> listGekoppeldeZaakEnkelvoudigInformatieobjectenVoorZaak(
             final URI zaakURI,
             final RelatieType relatieType) {
         final Zaak zaak = zrcClientService.readZaak(zaakURI);
-        final ZaakInformatieobjectListParameters parameters = new ZaakInformatieobjectListParameters();
-        parameters.setZaak(zaak.getUrl());
-        final List<ZaakInformatieobject> zaakInformatieobjects = zrcClientService.listZaakinformatieobjecten(
-                parameters);
-        return zaakInformatieobjects.stream()
-                .map(zaakInformatieobject -> informatieobjectConverter.convertToREST(zaakInformatieobject, relatieType,
-                                                                                     zaak))
+        return zrcClientService.listZaakinformatieobjecten(zaak).stream()
+                .map(zaakInformatieobject ->
+                             informatieobjectConverter.convertToREST(zaakInformatieobject, relatieType, zaak))
                 .toList();
     }
 

--- a/src/main/java/net/atos/zac/app/informatieobjecten/converter/RESTZaakInformatieobjectConverter.java
+++ b/src/main/java/net/atos/zac/app/informatieobjecten/converter/RESTZaakInformatieobjectConverter.java
@@ -40,7 +40,7 @@ public class RESTZaakInformatieobjectConverter {
     public RESTZaakInformatieobject convert(final ZaakInformatieobject zaakInformatieObject) {
         final Zaak zaak = zrcClientService.readZaak(zaakInformatieObject.getZaak());
         final Zaaktype zaaktype = ztcClientService.readZaaktype(zaak.getZaaktype());
-        final ZaakRechten zaakrechten = policyService.readZaakRechten(zaak, zaaktype);
+        final ZaakRechten zaakrechten = policyService.readZaakRechten(zaak);
         final RESTZaakInformatieobject restZaakInformatieobject = new RESTZaakInformatieobject();
         restZaakInformatieobject.zaakIdentificatie = zaak.getIdentificatie();
         restZaakInformatieobject.zaakRechten = rechtenConverter.convert(zaakrechten);

--- a/src/main/java/net/atos/zac/app/planitems/PlanItemsRESTService.java
+++ b/src/main/java/net/atos/zac/app/planitems/PlanItemsRESTService.java
@@ -209,7 +209,7 @@ public class PlanItemsRESTService {
                                            humanTaskData.medewerker != null ? humanTaskData.medewerker.id : null,
                                            fataleDatum,
                                            humanTaskData.taakdata, zaakUUID);
-        indexeerService.addZaak(zaakUUID, false);
+        indexeerService.addZaak(zaakUUID, false, false);
     }
 
     @POST

--- a/src/main/java/net/atos/zac/app/taken/TakenRESTService.java
+++ b/src/main/java/net/atos/zac/app/taken/TakenRESTService.java
@@ -266,7 +266,7 @@ public class TakenRESTService {
         taakVariabelenService.setTaakdata(task, restTaak.taakdata);
         taakVariabelenService.setTaakinformatie(task, restTaak.taakinformatie);
         final HistoricTaskInstance completedTask = takenService.completeTask(task);
-        indexeerService.addZaak(restTaak.zaakUuid, false);
+        indexeerService.addZaak(restTaak.zaakUuid, false, false);
         eventingService.send(TAAK.updated(completedTask));
         eventingService.send(ZAAK_TAKEN.updated(restTaak.zaakUuid));
         return taakConverter.convert(completedTask);

--- a/src/main/java/net/atos/zac/app/taken/converter/RESTTaakConverter.java
+++ b/src/main/java/net/atos/zac/app/taken/converter/RESTTaakConverter.java
@@ -69,7 +69,8 @@ public class RESTTaakConverter {
         restTaak.zaakUuid = taakVariabelenService.readZaakUUID(taskInfo);
         restTaak.zaakIdentificatie = taakVariabelenService.readZaakIdentificatie(taskInfo);
         final var zaaktypeOmschrijving = taakVariabelenService.readZaaktypeOmschrijving(taskInfo);
-        final var rechten = policyService.readTaakRechten(zaaktypeOmschrijving);
+        final var zaaktypeDomein = taakVariabelenService.readZaaktypeDomein(taskInfo);
+        final var rechten = policyService.readTaakRechten(zaaktypeDomein);
         restTaak.rechten = rechtenConverter.convert(rechten);
         if (rechten.getLezen()) {
             restTaak.zaaktypeOmschrijving = zaaktypeOmschrijving;
@@ -114,11 +115,10 @@ public class RESTTaakConverter {
     private void verwerkZaakafhandelParameters(final RESTTaak restTaak,
             final HumanTaskParameters humanTaskParameters) {
         restTaak.formulierDefinitie = humanTaskParameters.getFormulierDefinitieID();
-        humanTaskParameters.getReferentieTabellen().forEach(referentieTabel -> {
-            restTaak.tabellen.put(referentieTabel.getVeld(),
-                                  referentieTabel.getTabel().getWaarden().stream()
-                                          .map(ReferentieTabelWaarde::getNaam)
-                                          .toList());
-        });
+        humanTaskParameters.getReferentieTabellen().forEach(
+                referentieTabel -> restTaak.tabellen.put(referentieTabel.getVeld(),
+                                                         referentieTabel.getTabel().getWaarden().stream()
+                                                                 .map(ReferentieTabelWaarde::getNaam)
+                                                                 .toList()));
     }
 }

--- a/src/main/java/net/atos/zac/app/zaken/ZakenRESTService.java
+++ b/src/main/java/net/atos/zac/app/zaken/ZakenRESTService.java
@@ -53,7 +53,6 @@ import net.atos.client.zgw.drc.DRCClientService;
 import net.atos.client.zgw.drc.model.EnkelvoudigInformatieobject;
 import net.atos.client.zgw.shared.ZGWApiService;
 import net.atos.client.zgw.shared.model.audit.AuditTrailRegel;
-import net.atos.client.zgw.shared.util.URIUtil;
 import net.atos.client.zgw.zrc.ZRCClientService;
 import net.atos.client.zgw.zrc.model.BetrokkeneType;
 import net.atos.client.zgw.zrc.model.GeometryZaakPatch;
@@ -463,7 +462,7 @@ public class ZakenRESTService {
             final LocalDate vandaag,
             final Map<UUID, LocalDate> einddatumGeplandWaarschuwing,
             final Map<UUID, LocalDate> uiterlijkeEinddatumAfdoeningWaarschuwing) {
-        final UUID zaaktypeUUID = URIUtil.parseUUIDFromResourceURI(zaak.getZaaktype());
+        final UUID zaaktypeUUID = UriUtil.uuidFromURI(zaak.getZaaktype());
         return (zaak.getEinddatumGepland() != null &&
                 isWaarschuwing(vandaag, zaak.getEinddatumGepland(), einddatumGeplandWaarschuwing.get(zaaktypeUUID))) ||
                 isWaarschuwing(vandaag, zaak.getUiterlijkeEinddatumAfdoening(),
@@ -902,7 +901,7 @@ public class ZakenRESTService {
         System.out.println("koppelHoofdEnDeelzaak ZAAK.updated " + hoofdzaak.getUuid());
         // Hiervoor wordt door open zaak alleen voor de deelzaak een notificatie verstuurd.
         // Dus zelf het ScreenEvent versturen voor de hoofdzaak!
-        indexeerService.addZaak(hoofdzaak.getUuid(), false);
+        indexeerService.addZaak(hoofdzaak.getUuid(), false, false);
         eventingService.send(ZAAK.updated(hoofdzaak.getUuid()));
     }
 
@@ -911,7 +910,7 @@ public class ZakenRESTService {
         zrcClientService.patchZaak(deelzaakUUID, deelzaakPatch, reden);
         // Hiervoor wordt door open zaak alleen voor de deelzaak een notificatie verstuurd.
         // Dus zelf het ScreenEvent versturen voor de hoofdzaak!
-        indexeerService.addZaak(hoofdzaakUUID, false);
+        indexeerService.addZaak(hoofdzaakUUID, false, false);
         eventingService.send(ZAAK.updated(hoofdzaakUUID));
     }
 }

--- a/src/main/java/net/atos/zac/app/zaken/converter/RESTGerelateerdeZaakConverter.java
+++ b/src/main/java/net/atos/zac/app/zaken/converter/RESTGerelateerdeZaakConverter.java
@@ -35,7 +35,7 @@ public class RESTGerelateerdeZaakConverter {
 
     public RESTGerelateerdeZaak convert(final Zaak zaak, final RelatieType relatieType) {
         final Zaaktype zaaktype = ztcClientService.readZaaktype(zaak.getZaaktype());
-        final ZaakRechten zaakrechten = policyService.readZaakRechten(zaak, zaaktype);
+        final ZaakRechten zaakrechten = policyService.readZaakRechten(zaak);
         final RESTGerelateerdeZaak restGerelateerdeZaak = new RESTGerelateerdeZaak();
         restGerelateerdeZaak.identificatie = zaak.getIdentificatie();
         restGerelateerdeZaak.relatieType = relatieType;

--- a/src/main/java/net/atos/zac/app/zaken/converter/RESTZaakConverter.java
+++ b/src/main/java/net/atos/zac/app/zaken/converter/RESTZaakConverter.java
@@ -197,7 +197,7 @@ public class RESTZaakConverter {
         restZaak.isOntvangstbevestigingVerstuurd =
                 zaakVariabelenService.findOntvangstbevestigingVerstuurd(zaak.getUuid()).orElse(false);
         restZaak.isBesluittypeAanwezig = isNotEmpty(zaaktype.getBesluittypen());
-        restZaak.rechten = rechtenConverter.convert(policyService.readZaakRechten(zaak, zaaktype));
+        restZaak.rechten = rechtenConverter.convert(policyService.readZaakRechten(zaak));
 
         restZaak.zaakdata = zaakVariabelenService.readZaakdata(zaak.getUuid());
 
@@ -217,7 +217,7 @@ public class RESTZaakConverter {
             vrlClientService.findCommunicatiekanaal(
                             restZaak.communicatiekanaal.uuid)
                     .map(CommunicatieKanaal::getUrl)
-                    .ifPresent(communicatieKanaal -> zaak.setCommunicatiekanaal(communicatieKanaal));
+                    .ifPresent(zaak::setCommunicatiekanaal);
         }
 
         if (restZaak.vertrouwelijkheidaanduiding != null) {
@@ -244,7 +244,7 @@ public class RESTZaakConverter {
         if (restZaak.communicatiekanaal != null) {
             vrlClientService.findCommunicatiekanaal(restZaak.communicatiekanaal.uuid)
                     .map(CommunicatieKanaal::getUrl)
-                    .ifPresent(communicatieKanaal -> zaak.setCommunicatiekanaal(communicatieKanaal));
+                    .ifPresent(zaak::setCommunicatiekanaal);
         }
         zaak.setZaakgeometrie(restGeometryConverter.convert(restZaak.zaakgeometrie));
         return zaak;

--- a/src/main/java/net/atos/zac/app/zaken/converter/RESTZaakOverzichtConverter.java
+++ b/src/main/java/net/atos/zac/app/zaken/converter/RESTZaakOverzichtConverter.java
@@ -50,7 +50,7 @@ public class RESTZaakOverzichtConverter {
 
     public RESTZaakOverzicht convert(final Zaak zaak) {
         final Zaaktype zaaktype = ztcClientService.readZaaktype(zaak.getZaaktype());
-        final ZaakRechten zaakrechten = policyService.readZaakRechten(zaak, zaaktype);
+        final ZaakRechten zaakrechten = policyService.readZaakRechten(zaak);
         final RESTZaakOverzicht restZaakOverzicht = new RESTZaakOverzicht();
         restZaakOverzicht.uuid = zaak.getUuid();
         restZaakOverzicht.identificatie = zaak.getIdentificatie();

--- a/src/main/java/net/atos/zac/app/zoeken/converter/RESTDocumentZoekObjectConverter.java
+++ b/src/main/java/net/atos/zac/app/zoeken/converter/RESTDocumentZoekObjectConverter.java
@@ -34,6 +34,7 @@ public class RESTDocumentZoekObjectConverter {
         restDocumentZoekObject.zaaktypeUuid = documentZoekObject.getZaaktypeUuid();
         restDocumentZoekObject.zaaktypeIdentificatie = documentZoekObject.getZaaktypeIdentificatie();
         restDocumentZoekObject.zaaktypeOmschrijving = documentZoekObject.getZaaktypeOmschrijving();
+        restDocumentZoekObject.zaaktypeDomein = documentZoekObject.getZaaktypeDomein();
         restDocumentZoekObject.zaakIdentificatie = documentZoekObject.getZaakIdentificatie();
         restDocumentZoekObject.zaakUuid = documentZoekObject.getZaakUuid();
         restDocumentZoekObject.zaakRelatie = documentZoekObject.getZaakRelatie();

--- a/src/main/java/net/atos/zac/app/zoeken/converter/RESTTaakZoekObjectConverter.java
+++ b/src/main/java/net/atos/zac/app/zoeken/converter/RESTTaakZoekObjectConverter.java
@@ -36,6 +36,7 @@ public class RESTTaakZoekObjectConverter {
         restTaakZoekObject.behandelaarNaam = taakZoekObject.getBehandelaarNaam();
         restTaakZoekObject.behandelaarGebruikersnaam = taakZoekObject.getBehandelaarGebruikersnaam();
         restTaakZoekObject.zaaktypeOmschrijving = taakZoekObject.getZaaktypeOmschrijving();
+        restTaakZoekObject.zaaktypeDomein = taakZoekObject.getZaaktypeDomein();
         restTaakZoekObject.zaakIdentificatie = taakZoekObject.getZaakIdentificatie();
         restTaakZoekObject.zaakUuid = taakZoekObject.getZaakUUID();
         restTaakZoekObject.zaakToelichting = taakZoekObject.getZaakToelichting();

--- a/src/main/java/net/atos/zac/app/zoeken/converter/RESTZaakZoekObjectConverter.java
+++ b/src/main/java/net/atos/zac/app/zoeken/converter/RESTZaakZoekObjectConverter.java
@@ -44,6 +44,7 @@ public class RESTZaakZoekObjectConverter {
         restZoekItem.behandelaarGebruikersnaam = zoekItem.getBehandelaarGebruikersnaam();
         restZoekItem.initiatorIdentificatie = zoekItem.getInitiatorIdentificatie();
         restZoekItem.zaaktypeOmschrijving = zoekItem.getZaaktypeOmschrijving();
+        restZoekItem.zaaktypeDomein = zoekItem.getZaaktypeDomein();
         restZoekItem.statustypeOmschrijving = zoekItem.getStatustypeOmschrijving();
         restZoekItem.resultaattypeOmschrijving = zoekItem.getResultaattypeOmschrijving();
         restZoekItem.aantalOpenstaandeTaken = zoekItem.getAantalOpenstaandeTaken();

--- a/src/main/java/net/atos/zac/app/zoeken/model/RESTDocumentZoekObject.java
+++ b/src/main/java/net/atos/zac/app/zoeken/model/RESTDocumentZoekObject.java
@@ -23,6 +23,8 @@ public class RESTDocumentZoekObject extends AbstractRESTZoekObject {
 
     public String zaaktypeOmschrijving;
 
+    public String zaaktypeDomein;
+
     public String zaakIdentificatie;
 
     public String zaakUuid;

--- a/src/main/java/net/atos/zac/app/zoeken/model/RESTTaakZoekObject.java
+++ b/src/main/java/net/atos/zac/app/zoeken/model/RESTTaakZoekObject.java
@@ -33,6 +33,8 @@ public class RESTTaakZoekObject extends AbstractRESTZoekObject {
 
     public String zaaktypeOmschrijving;
 
+    public String zaaktypeDomein;
+
     public LocalDate creatiedatum;
 
     public LocalDate toekenningsdatum;

--- a/src/main/java/net/atos/zac/app/zoeken/model/RESTZaakZoekObject.java
+++ b/src/main/java/net/atos/zac/app/zoeken/model/RESTZaakZoekObject.java
@@ -65,6 +65,8 @@ public class RESTZaakZoekObject extends AbstractRESTZoekObject {
 
     public String zaaktypeOmschrijving;
 
+    public String zaaktypeDomein;
+
     public String resultaattypeOmschrijving;
 
     public String resultaatToelichting;

--- a/src/main/java/net/atos/zac/documenten/InboxDocumentenService.java
+++ b/src/main/java/net/atos/zac/documenten/InboxDocumentenService.java
@@ -27,12 +27,12 @@ import org.apache.commons.lang3.StringUtils;
 import net.atos.client.zgw.drc.DRCClientService;
 import net.atos.client.zgw.drc.model.EnkelvoudigInformatieobject;
 import net.atos.client.zgw.shared.util.DateTimeUtil;
-import net.atos.client.zgw.shared.util.URIUtil;
 import net.atos.client.zgw.zrc.ZRCClientService;
 import net.atos.client.zgw.zrc.model.ZaakInformatieobject;
 import net.atos.zac.documenten.model.InboxDocument;
 import net.atos.zac.documenten.model.InboxDocumentListParameters;
 import net.atos.zac.shared.model.SorteerRichting;
+import net.atos.zac.util.UriUtil;
 import net.atos.zac.zoeken.model.DatumRange;
 
 @ApplicationScoped
@@ -103,8 +103,7 @@ public class InboxDocumentenService {
     public void delete(final UUID zaakinformatieobjectUUID) {
         final ZaakInformatieobject zaakInformatieobject = zrcClientService.readZaakinformatieobject(
                 zaakinformatieobjectUUID);
-        final UUID enkelvoudiginformatieobjectUUID = URIUtil.parseUUIDFromResourceURI(
-                zaakInformatieobject.getInformatieobject());
+        final UUID enkelvoudiginformatieobjectUUID = UriUtil.uuidFromURI(zaakInformatieobject.getInformatieobject());
         find(enkelvoudiginformatieobjectUUID).ifPresent(entityManager::remove);
     }
 

--- a/src/main/java/net/atos/zac/flowable/CMMNService.java
+++ b/src/main/java/net/atos/zac/flowable/CMMNService.java
@@ -5,6 +5,7 @@
 
 package net.atos.zac.flowable;
 
+import static net.atos.zac.flowable.ZaakVariabelenService.VAR_ZAAKTYPE_DOMEIN;
 import static net.atos.zac.flowable.ZaakVariabelenService.VAR_ZAAKTYPE_OMSCHRIJVING;
 import static net.atos.zac.flowable.ZaakVariabelenService.VAR_ZAAKTYPE_UUUID;
 import static net.atos.zac.flowable.ZaakVariabelenService.VAR_ZAAK_DATA;
@@ -109,7 +110,8 @@ public class CMMNService {
                     .variable(VAR_ZAAK_UUID, zaak.getUuid())
                     .variable(VAR_ZAAK_IDENTIFICATIE, zaak.getIdentificatie())
                     .variable(VAR_ZAAKTYPE_UUUID, zaaktype.getUUID())
-                    .variable(VAR_ZAAKTYPE_OMSCHRIJVING, zaaktype.getOmschrijving());
+                    .variable(VAR_ZAAKTYPE_OMSCHRIJVING, zaaktype.getOmschrijving())
+                    .variable(VAR_ZAAKTYPE_DOMEIN, zaakafhandelParameters.getDomein());
             if (zaakData != null) {
                 caseInstanceBuilder.variable(VAR_ZAAK_DATA, zaakData);
             }

--- a/src/main/java/net/atos/zac/flowable/TaakVariabelenService.java
+++ b/src/main/java/net/atos/zac/flowable/TaakVariabelenService.java
@@ -5,6 +5,7 @@
 
 package net.atos.zac.flowable;
 
+import static net.atos.zac.flowable.ZaakVariabelenService.VAR_ZAAKTYPE_DOMEIN;
 import static net.atos.zac.flowable.ZaakVariabelenService.VAR_ZAAKTYPE_OMSCHRIJVING;
 import static net.atos.zac.flowable.ZaakVariabelenService.VAR_ZAAKTYPE_UUUID;
 import static net.atos.zac.flowable.ZaakVariabelenService.VAR_ZAAK_IDENTIFICATIE;
@@ -78,6 +79,10 @@ public class TaakVariabelenService {
 
     public String readZaaktypeOmschrijving(final TaskInfo taskInfo) {
         return (String) readVariable(taskInfo, VAR_ZAAKTYPE_OMSCHRIJVING);
+    }
+
+    public String readZaaktypeDomein(final TaskInfo taskInfo) {
+        return (String) findTaskVariable(taskInfo, VAR_ZAAKTYPE_DOMEIN).orElse(null);
     }
 
     private Map<String, Object> getVariables(final TaskInfo taskInfo) {

--- a/src/main/java/net/atos/zac/flowable/ZaakVariabelenService.java
+++ b/src/main/java/net/atos/zac/flowable/ZaakVariabelenService.java
@@ -28,6 +28,8 @@ public class ZaakVariabelenService {
 
     public static final String VAR_ZAAKTYPE_OMSCHRIJVING = "zaaktypeOmschrijving";
 
+    public static final String VAR_ZAAKTYPE_DOMEIN = "zaaktypeDomein";
+
     static final String VAR_ZAAK_DATA = "zaakData";
 
     private static final String VAR_ONTVANGSTBEVESTIGING_VERSTUURD = "ontvangstbevestigingVerstuurd";
@@ -59,6 +61,11 @@ public class ZaakVariabelenService {
 
     public String readZaaktypeOmschrijving(final PlanItemInstance planItemInstance) {
         return (String) readCaseVariable(planItemInstance, VAR_ZAAKTYPE_OMSCHRIJVING);
+    }
+
+    public Optional<String> readZaaktypeDomein(final PlanItemInstance planItemInstance) {
+        final Object caseVariable = findCaseVariable(planItemInstance, VAR_ZAAKTYPE_DOMEIN);
+        return caseVariable != null ? Optional.of((String) caseVariable) : Optional.empty();
     }
 
     public Optional<Boolean> findOntvangstbevestigingVerstuurd(final UUID zaakUUID) {
@@ -110,6 +117,16 @@ public class ZaakVariabelenService {
     }
 
     private Object readCaseVariable(final PlanItemInstance planItemInstance, final String variableName) {
+        final Object caseVariabele = findCaseVariable(planItemInstance, variableName);
+        if (caseVariabele == null) {
+            throw new RuntimeException(
+                    String.format("No variable found with name '%s' for case instance id '%s'", variableName,
+                                  planItemInstance.getCaseInstanceId()));
+        }
+        return caseVariabele;
+    }
+
+    private Object findCaseVariable(final PlanItemInstance planItemInstance, final String variableName) {
         final CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceQuery()
                 .caseInstanceId(planItemInstance.getCaseInstanceId())
                 .includeCaseVariables()
@@ -126,9 +143,7 @@ public class ZaakVariabelenService {
             return historicCaseInstance.getCaseVariables().get(variableName);
         }
 
-        throw new RuntimeException(
-                String.format("No variable found with name '%s' for case instance id '%s'", variableName,
-                              planItemInstance.getCaseInstanceId()));
+        return null;
     }
 
     private Object findCaseVariable(final UUID zaakUUID, final String variableName) {

--- a/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
+++ b/src/main/java/net/atos/zac/notificaties/NotificatieReceiver.java
@@ -124,14 +124,16 @@ public class NotificatieReceiver {
 
     private void handleWebsockets(final Notificatie notificatie) {
         if (notificatie.getChannel() != null && notificatie.getResource() != null) {
-            ScreenEventType.getEvents(notificatie.getChannel(), notificatie.getMainResourceInfo(), notificatie.getResourceInfo())
+            ScreenEventType.getEvents(notificatie.getChannel(), notificatie.getMainResourceInfo(),
+                                      notificatie.getResourceInfo())
                     .forEach(eventingService::send);
         }
     }
 
     private void handleSignaleringen(final Notificatie notificatie) {
         if (notificatie.getChannel() != null && notificatie.getResource() != null) {
-            SignaleringEventUtil.getEvents(notificatie.getChannel(), notificatie.getMainResourceInfo(), notificatie.getResourceInfo())
+            SignaleringEventUtil.getEvents(notificatie.getChannel(), notificatie.getMainResourceInfo(),
+                                           notificatie.getResourceInfo())
                     .forEach(eventingService::send);
         }
     }
@@ -147,7 +149,8 @@ public class NotificatieReceiver {
         if (notificatie.getResource() != OBJECT || notificatie.getAction() != CREATE || isEmpty(producttypeUri)) {
             return false;
         }
-        return PRODUCTAANVRAAG_OBJECTTYPE_NAME.equals(objecttypesClientService.readObjecttype(uuidFromURI(producttypeUri)).getName());
+        return PRODUCTAANVRAAG_OBJECTTYPE_NAME.equals(
+                objecttypesClientService.readObjecttype(uuidFromURI(producttypeUri)).getName());
     }
 
     private void handleIndexering(final Notificatie notificatie) {
@@ -155,12 +158,13 @@ public class NotificatieReceiver {
             if (notificatie.getResource() == ZAAK) {
                 if (notificatie.getAction() == CREATE || notificatie.getAction() == UPDATE) {
                     // Updaten van taak is nodig bij afsluiten zaak
-                    indexeerService.addZaak(uuidFromURI(notificatie.getResourceUrl()), notificatie.getAction() == UPDATE);
+                    indexeerService.addZaak(uuidFromURI(notificatie.getResourceUrl()),
+                                            notificatie.getAction() == UPDATE, false);
                 } else if (notificatie.getAction() == DELETE) {
                     indexeerService.removeZaak(uuidFromURI(notificatie.getResourceUrl()));
                 }
             } else if (notificatie.getResource() == STATUS || notificatie.getResource() == RESULTAAT || notificatie.getResource() == ROL) {
-                indexeerService.addZaak(uuidFromURI(notificatie.getMainResourceUrl()), false);
+                indexeerService.addZaak(uuidFromURI(notificatie.getMainResourceUrl()), false, false);
             } else if (notificatie.getResource() == ZAAKINFORMATIEOBJECT && notificatie.getAction() == CREATE) {
                 indexeerService.addInformatieobjectByZaakinformatieobject(uuidFromURI(notificatie.getResourceUrl()));
             }

--- a/src/main/java/net/atos/zac/policy/OPAEvaluationClient.java
+++ b/src/main/java/net/atos/zac/policy/OPAEvaluationClient.java
@@ -8,7 +8,6 @@ package net.atos.zac.policy;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 import java.util.List;
-import java.util.Set;
 
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -19,6 +18,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import net.atos.client.opa.model.RuleQuery;
 import net.atos.client.opa.model.RuleResponse;
 import net.atos.zac.policy.input.DocumentInput;
+import net.atos.zac.policy.input.NoInput;
 import net.atos.zac.policy.input.TaakInput;
 import net.atos.zac.policy.input.UserInput;
 import net.atos.zac.policy.input.ZaakInput;
@@ -34,8 +34,8 @@ import net.atos.zac.policy.output.ZaakRechten;
 public interface OPAEvaluationClient {
 
     @POST
-    @Path("zaaktype/zaaktypen")
-    RuleResponse<List<Set<String>>> readZaaktypen(final RuleQuery<UserInput> query);
+    @Path("rol/rollen")
+    RuleResponse<List<String>> readRollen(final RuleQuery<NoInput> query);
 
     @POST
     @Path("zaak/zaak_rechten")

--- a/src/main/java/net/atos/zac/policy/PolicyService.java
+++ b/src/main/java/net/atos/zac/policy/PolicyService.java
@@ -7,7 +7,8 @@ package net.atos.zac.policy;
 
 import static net.atos.client.zgw.drc.model.InformatieobjectStatus.DEFINITIEF;
 
-import java.util.List;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -18,11 +19,8 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.flowable.task.api.TaskInfo;
 
 import net.atos.client.opa.model.RuleQuery;
-import net.atos.client.opa.model.RuleResponse;
 import net.atos.client.zgw.drc.model.AbstractEnkelvoudigInformatieobject;
 import net.atos.client.zgw.zrc.model.Zaak;
-import net.atos.client.zgw.ztc.ZTCClientService;
-import net.atos.client.zgw.ztc.model.Zaaktype;
 import net.atos.zac.authentication.LoggedInUser;
 import net.atos.zac.enkelvoudiginformatieobject.EnkelvoudigInformatieObjectLockService;
 import net.atos.zac.enkelvoudiginformatieobject.model.EnkelvoudigInformatieObjectLock;
@@ -30,6 +28,7 @@ import net.atos.zac.flowable.TaakVariabelenService;
 import net.atos.zac.policy.exception.PolicyException;
 import net.atos.zac.policy.input.DocumentData;
 import net.atos.zac.policy.input.DocumentInput;
+import net.atos.zac.policy.input.NoInput;
 import net.atos.zac.policy.input.TaakData;
 import net.atos.zac.policy.input.TaakInput;
 import net.atos.zac.policy.input.UserInput;
@@ -40,6 +39,9 @@ import net.atos.zac.policy.output.OverigeRechten;
 import net.atos.zac.policy.output.TaakRechten;
 import net.atos.zac.policy.output.WerklijstRechten;
 import net.atos.zac.policy.output.ZaakRechten;
+import net.atos.zac.util.UriUtil;
+import net.atos.zac.zaaksturing.ZaakafhandelParameterService;
+import net.atos.zac.zaaksturing.model.ZaakafhandelParameters;
 import net.atos.zac.zoeken.model.DocumentIndicatie;
 import net.atos.zac.zoeken.model.zoekobject.DocumentZoekObject;
 import net.atos.zac.zoeken.model.zoekobject.TaakZoekObject;
@@ -48,7 +50,7 @@ import net.atos.zac.zoeken.model.zoekobject.ZaakZoekObject;
 @ApplicationScoped
 public class PolicyService {
 
-    private static final String ALLE_ZAAKTYPEN = "-ALLE-ZAAKTYPEN-";
+    private static final String ALLE_DOMEINEN = "domein_elk_zaaktype";
 
     @Inject
     private Instance<LoggedInUser> loggedInUserInstance;
@@ -58,27 +60,32 @@ public class PolicyService {
     private OPAEvaluationClient evaluationClient;
 
     @Inject
-    private ZTCClientService ztcClientService;
-
-    @Inject
     private EnkelvoudigInformatieObjectLockService lockService;
 
     @Inject
     private TaakVariabelenService taakVariabelenService;
+
+    @Inject
+    private ZaakafhandelParameterService zaakafhandelParameterService;
 
     public OverigeRechten readOverigeRechten() {
         return evaluationClient.readOverigeRechten(new RuleQuery<>(new UserInput(loggedInUserInstance.get())))
                 .getResult();
     }
 
-    public ZaakRechten readZaakRechten(final Zaak zaak) {
-        return readZaakRechten(zaak, ztcClientService.readZaaktype(zaak.getZaaktype()));
+    private ZaakafhandelParameters readZaakafhandelParameters(final Zaak zaak) {
+        return zaakafhandelParameterService.readZaakafhandelParameters(
+                UriUtil.uuidFromURI(zaak.getZaaktype()));
     }
 
-    public ZaakRechten readZaakRechten(final Zaak zaak, final Zaaktype zaaktype) {
+    public ZaakRechten readZaakRechten(final Zaak zaak) {
+        return readZaakRechten(zaak, readZaakafhandelParameters(zaak));
+    }
+
+    public ZaakRechten readZaakRechten(final Zaak zaak, final ZaakafhandelParameters zaakafhandelParameters) {
         final ZaakData zaakData = new ZaakData();
         zaakData.open = zaak.isOpen();
-        zaakData.zaaktype = zaaktype.getOmschrijving();
+        zaakData.domein = zaakafhandelParameters.getDomein();
         return evaluationClient.readZaakRechten(new RuleQuery<>(new ZaakInput(loggedInUserInstance.get(), zaakData)))
                 .getResult();
     }
@@ -86,7 +93,7 @@ public class PolicyService {
     public ZaakRechten readZaakRechten(final ZaakZoekObject zaakZoekObject) {
         final ZaakData zaakData = new ZaakData();
         zaakData.open = !zaakZoekObject.isAfgehandeld();
-        zaakData.zaaktype = zaakZoekObject.getZaaktypeOmschrijving();
+        zaakData.domein = zaakZoekObject.getZaaktypeDomein();
         return evaluationClient.readZaakRechten(new RuleQuery<>(new ZaakInput(loggedInUserInstance.get(), zaakData)))
                 .getResult();
     }
@@ -110,7 +117,7 @@ public class PolicyService {
         documentData.vergrendeldDoor = lock != null ? lock.getUserId() : null;
         if (zaak != null) {
             documentData.zaakOpen = zaak.isOpen();
-            documentData.zaaktype = ztcClientService.readZaaktype(zaak.getZaaktype()).getOmschrijving();
+            documentData.domein = readZaakafhandelParameters(zaak).getDomein();
         }
         return evaluationClient.readDocumentRechten(
                 new RuleQuery<>(new DocumentInput(loggedInUserInstance.get(), documentData))).getResult();
@@ -122,25 +129,25 @@ public class PolicyService {
         documentData.vergrendeld = enkelvoudigInformatieobject.isIndicatie(DocumentIndicatie.VERGRENDELD);
         documentData.vergrendeldDoor = enkelvoudigInformatieobject.getVergrendeldDoorGebruikersnaam();
         documentData.zaakOpen = !enkelvoudigInformatieobject.isZaakAfgehandeld();
-        documentData.zaaktype = enkelvoudigInformatieobject.getZaaktypeOmschrijving();
+        documentData.domein = enkelvoudigInformatieobject.getZaaktypeDomein();
         return evaluationClient.readDocumentRechten(
                 new RuleQuery<>(new DocumentInput(loggedInUserInstance.get(), documentData))).getResult();
     }
 
     public TaakRechten readTaakRechten(final TaskInfo taskInfo) {
-        return readTaakRechten(taakVariabelenService.readZaaktypeOmschrijving(taskInfo));
+        return readTaakRechten(taakVariabelenService.readZaaktypeDomein(taskInfo));
     }
 
-    public TaakRechten readTaakRechten(final String zaaktypeOmschrijving) {
+    public TaakRechten readTaakRechten(final String zaaktypeDomein) {
         final TaakData taakData = new TaakData();
-        taakData.zaaktype = zaaktypeOmschrijving;
+        taakData.domein = zaaktypeDomein;
         return evaluationClient.readTaakRechten(new RuleQuery<>(new TaakInput(loggedInUserInstance.get(), taakData)))
                 .getResult();
     }
 
     public TaakRechten readTaakRechten(final TaakZoekObject taakZoekObject) {
         final TaakData taakData = new TaakData();
-        taakData.zaaktype = taakZoekObject.getZaaktypeOmschrijving();
+        taakData.domein = taakZoekObject.getZaaktypeDomein();
         return evaluationClient.readTaakRechten(new RuleQuery<>(new TaakInput(loggedInUserInstance.get(), taakData)))
                 .getResult();
     }
@@ -151,40 +158,31 @@ public class PolicyService {
     }
 
     /**
-     * Get the set of allowed zaaktypen.
-     * Returns null if all zaaktypen are allowed.
+     * Get the set of allowed domeinen.
+     * Returns null if all domeinen are allowed.
      *
-     * @return Set of allowed zaaktypen which may be empty. Or null indicating that all zaaktypen are allowed.
+     * @return Set of allowed domeinen which may be empty. Or null indicating that all domeinen are allowed.
      */
-    public Set<String> getAllowedZaaktypen() {
-        final Set<String> zaaktypen = readZaaktypen();
-        return zaaktypen.contains(ALLE_ZAAKTYPEN) ? null : zaaktypen;
+    public Set<String> getAllowedDomeinenForUser() {
+        final Set<String> userDomeinen = listDomeinenForUser();
+        return userDomeinen.contains(ALLE_DOMEINEN) ? null : userDomeinen;
     }
 
-    public List<Zaaktype> filterAllowedZaaktypen(final List<Zaaktype> alleZaaktypen) {
-        final Set<String> zaaktypenAllowed = readZaaktypen();
-        if (zaaktypenAllowed.contains(ALLE_ZAAKTYPEN)) {
-            return alleZaaktypen;
-        } else {
-            return alleZaaktypen.stream().filter(zaaktype -> zaaktypenAllowed.contains(zaaktype.getOmschrijving()))
-                    .toList();
-        }
+    public boolean isDomeinAllowedForUser(final String domein) {
+        final Set<String> userDomeinen = listDomeinenForUser();
+        return userDomeinen.contains(ALLE_DOMEINEN) || userDomeinen.contains(domein);
     }
 
-    public boolean isZaaktypeAllowed(final String zaaktype) {
-        final Set<String> zaaktypenAllowed = readZaaktypen();
-        return zaaktypenAllowed.contains(ALLE_ZAAKTYPEN) || zaaktypenAllowed.contains(zaaktype);
+    private Set<String> listDomeinenForUser() {
+        final Set<String> userDomeinen = new HashSet<>(loggedInUserInstance.get().getRoles());
+        evaluationClient.readRollen(NoInput.QUERY).getResult()
+                .forEach(userDomeinen::remove);
+        return Collections.unmodifiableSet(userDomeinen);
     }
 
     public static void assertPolicy(final boolean policy) {
         if (!policy) {
             throw new PolicyException();
         }
-    }
-
-    private Set<String> readZaaktypen() {
-        final RuleQuery<UserInput> query = new RuleQuery<>(new UserInput(loggedInUserInstance.get()));
-        final RuleResponse<List<Set<String>>> response = evaluationClient.readZaaktypen(query);
-        return response.getResult().get(0);
     }
 }

--- a/src/main/java/net/atos/zac/policy/input/DocumentData.java
+++ b/src/main/java/net/atos/zac/policy/input/DocumentData.java
@@ -16,7 +16,7 @@ public class DocumentData {
     @JsonbProperty("vergrendeld_door")
     public String vergrendeldDoor;
 
-    public String zaaktype;
+    public String domein;
 
     @JsonbProperty("zaak_open")
     public Boolean zaakOpen;

--- a/src/main/java/net/atos/zac/policy/input/NoInput.java
+++ b/src/main/java/net/atos/zac/policy/input/NoInput.java
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Atos
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+package net.atos.zac.policy.input;
+
+import net.atos.client.opa.model.RuleQuery;
+
+@SuppressWarnings("InstantiationOfUtilityClass")
+public class NoInput {
+    public static final NoInput INPUT = new NoInput();
+
+    public static final RuleQuery<NoInput> QUERY = new RuleQuery<>(INPUT);
+
+    private NoInput() {
+    }
+}

--- a/src/main/java/net/atos/zac/policy/input/TaakData.java
+++ b/src/main/java/net/atos/zac/policy/input/TaakData.java
@@ -7,5 +7,5 @@ package net.atos.zac.policy.input;
 
 public class TaakData {
 
-    public String zaaktype;
+    public String domein;
 }

--- a/src/main/java/net/atos/zac/policy/input/ZaakData.java
+++ b/src/main/java/net/atos/zac/policy/input/ZaakData.java
@@ -9,5 +9,5 @@ public class ZaakData {
 
     public boolean open;
 
-    public String zaaktype;
+    public String domein;
 }

--- a/src/main/java/net/atos/zac/signalering/event/SignaleringEventObserver.java
+++ b/src/main/java/net/atos/zac/signalering/event/SignaleringEventObserver.java
@@ -16,7 +16,6 @@ import javax.inject.Inject;
 
 import org.flowable.task.api.TaskInfo;
 
-import net.atos.client.zgw.shared.util.URIUtil;
 import net.atos.client.zgw.zrc.ZRCClientService;
 import net.atos.client.zgw.zrc.model.BetrokkeneType;
 import net.atos.client.zgw.zrc.model.Rol;
@@ -35,6 +34,7 @@ import net.atos.zac.identity.model.User;
 import net.atos.zac.signalering.SignaleringenService;
 import net.atos.zac.signalering.model.Signalering;
 import net.atos.zac.signalering.model.SignaleringInstellingen;
+import net.atos.zac.util.UriUtil;
 
 /**
  * This bean listens for SignaleringEvents and handles them.
@@ -142,7 +142,7 @@ public class SignaleringEventObserver extends AbstractEventObserver<SignaleringE
                 final Zaak subject = zrcClientService.readZaak((URI) event.getObjectId().getResource());
                 final ZaakInformatieobject detail =
                         zrcClientService.readZaakinformatieobject(
-                                URIUtil.parseUUIDFromResourceURI((URI) event.getObjectId().getDetail()));
+                                UriUtil.uuidFromURI((URI) event.getObjectId().getDetail()));
                 return getSignaleringVoorBehandelaar(event, subject, detail);
             }
             case ZAAK_OP_NAAM -> {

--- a/src/main/java/net/atos/zac/signalering/model/Signalering.java
+++ b/src/main/java/net/atos/zac/signalering/model/Signalering.java
@@ -31,11 +31,11 @@ import javax.validation.constraints.NotNull;
 import org.flowable.task.api.TaskInfo;
 
 import net.atos.client.zgw.drc.model.EnkelvoudigInformatieobject;
-import net.atos.client.zgw.shared.util.URIUtil;
 import net.atos.client.zgw.zrc.model.Zaak;
 import net.atos.client.zgw.zrc.model.ZaakInformatieobject;
 import net.atos.zac.identity.model.Group;
 import net.atos.zac.identity.model.User;
+import net.atos.zac.util.UriUtil;
 
 /* Construction is easiest with the factory method in SignaleringService. */
 @Entity
@@ -130,7 +130,7 @@ public class Signalering {
 
     public void setSubject(final EnkelvoudigInformatieobject subject) {
         validSubjecttype(DOCUMENT);
-        this.subject = URIUtil.parseUUIDFromResourceURI(subject.getUrl()).toString();
+        this.subject = UriUtil.uuidFromURI(subject.getUrl()).toString();
     }
 
     private void validSubjecttype(final SignaleringSubject subjecttype) {
@@ -149,7 +149,7 @@ public class Signalering {
     }
 
     public void setDetail(final ZaakInformatieobject detail) {
-        this.detail = URIUtil.parseUUIDFromResourceURI(detail.getInformatieobject()).toString();
+        this.detail = UriUtil.uuidFromURI(detail.getInformatieobject()).toString();
     }
 
     public ZonedDateTime getTijdstip() {

--- a/src/main/java/net/atos/zac/signalering/model/SignaleringVerzondenZoekParameters.java
+++ b/src/main/java/net/atos/zac/signalering/model/SignaleringVerzondenZoekParameters.java
@@ -20,10 +20,10 @@ import java.util.UUID;
 import org.flowable.task.api.TaskInfo;
 
 import net.atos.client.zgw.drc.model.EnkelvoudigInformatieobject;
-import net.atos.client.zgw.shared.util.URIUtil;
 import net.atos.client.zgw.zrc.model.Zaak;
 import net.atos.zac.identity.model.Group;
 import net.atos.zac.identity.model.User;
+import net.atos.zac.util.UriUtil;
 
 public class SignaleringVerzondenZoekParameters {
     private final SignaleringTarget targettype;
@@ -95,7 +95,7 @@ public class SignaleringVerzondenZoekParameters {
     }
 
     public SignaleringVerzondenZoekParameters subject(final EnkelvoudigInformatieobject subject) {
-        return subjectInformatieobject(URIUtil.parseUUIDFromResourceURI(subject.getUrl()));
+        return subjectInformatieobject(UriUtil.uuidFromURI(subject.getUrl()));
     }
 
     public SignaleringVerzondenZoekParameters subjectZaak(final UUID zaakId) {

--- a/src/main/java/net/atos/zac/signalering/model/SignaleringZoekParameters.java
+++ b/src/main/java/net/atos/zac/signalering/model/SignaleringZoekParameters.java
@@ -20,10 +20,10 @@ import java.util.UUID;
 import org.flowable.task.api.TaskInfo;
 
 import net.atos.client.zgw.drc.model.EnkelvoudigInformatieobject;
-import net.atos.client.zgw.shared.util.URIUtil;
 import net.atos.client.zgw.zrc.model.Zaak;
 import net.atos.zac.identity.model.Group;
 import net.atos.zac.identity.model.User;
+import net.atos.zac.util.UriUtil;
 
 public class SignaleringZoekParameters {
     private final SignaleringTarget targettype;
@@ -93,7 +93,7 @@ public class SignaleringZoekParameters {
     }
 
     public SignaleringZoekParameters subject(final EnkelvoudigInformatieobject subject) {
-        return subjectInformatieobject(URIUtil.parseUUIDFromResourceURI(subject.getUrl()));
+        return subjectInformatieobject(UriUtil.uuidFromURI(subject.getUrl()));
     }
 
     public SignaleringZoekParameters subjectZaak(final UUID zaakId) {

--- a/src/main/java/net/atos/zac/util/FixUtilRESTService.java
+++ b/src/main/java/net/atos/zac/util/FixUtilRESTService.java
@@ -5,6 +5,7 @@
 
 package net.atos.zac.util;
 
+import static net.atos.zac.flowable.ZaakVariabelenService.VAR_ZAAKTYPE_DOMEIN;
 import static net.atos.zac.flowable.ZaakVariabelenService.VAR_ZAAKTYPE_OMSCHRIJVING;
 import static net.atos.zac.flowable.ZaakVariabelenService.VAR_ZAAKTYPE_UUUID;
 import static net.atos.zac.flowable.ZaakVariabelenService.VAR_ZAAK_IDENTIFICATIE;
@@ -53,6 +54,7 @@ public class FixUtilRESTService {
         countMissingVariable(VAR_ZAAK_IDENTIFICATIE);
         countMissingVariable(VAR_ZAAKTYPE_UUUID);
         countMissingVariable(VAR_ZAAKTYPE_OMSCHRIJVING);
+        countMissingVariable(VAR_ZAAKTYPE_DOMEIN);
         return Response.noContent().build();
     }
 

--- a/src/main/java/net/atos/zac/websocket/event/ScreenEventType.java
+++ b/src/main/java/net/atos/zac/websocket/event/ScreenEventType.java
@@ -17,12 +17,12 @@ import java.util.UUID;
 import org.flowable.task.api.TaskInfo;
 
 import net.atos.client.zgw.drc.model.EnkelvoudigInformatieobject;
-import net.atos.client.zgw.shared.util.URIUtil;
 import net.atos.client.zgw.zrc.model.Zaak;
 import net.atos.zac.event.Opcode;
 import net.atos.zac.notificaties.Channel;
 import net.atos.zac.notificaties.Notificatie;
 import net.atos.zac.signalering.model.Signalering;
+import net.atos.zac.util.UriUtil;
 
 /**
  * Enumeration of the type of objects that can be referenced by a {@link ScreenEvent} event.
@@ -104,9 +104,7 @@ public enum ScreenEventType {
 
     private static ScreenEvent instance(final Opcode opcode, final ScreenEventType type, final URI url,
             final URI detail) {
-        return instance(opcode, type,
-                        URIUtil.parseUUIDFromResourceURI(url),
-                        detail != null ? URIUtil.parseUUIDFromResourceURI(detail) : null);
+        return instance(opcode, type, UriUtil.uuidFromURI(url), detail != null ? UriUtil.uuidFromURI(detail) : null);
     }
 
     // These methods determine what is used as an id, so that it is the same everywhere

--- a/src/main/java/net/atos/zac/zoeken/ZoekenService.java
+++ b/src/main/java/net/atos/zac/zoeken/ZoekenService.java
@@ -49,9 +49,9 @@ public class ZoekenService {
 
     private static final String SOLR_CORE = "zac";
 
-    private static final String NON_EXISTING_ZAAKTYPE = quoted("-NON-EXISTING-ZAAKTYPE-");
+    private static final String NON_EXISTING_DOMEIN = quoted("-NON-EXISTING-DOMEIN-");
 
-    private static final String ZAAKTYPE_OMSCHRIJVING_VELD = "zaaktypeOmschrijving";
+    private static final String ZAAKTYPE_DOMEIN_VELD = "zaaktypeDomein";
 
     private static final char SOLR_ESCAPE = '\\';
 
@@ -60,7 +60,7 @@ public class ZoekenService {
     @Inject
     private PolicyService policyService;
 
-    private SolrClient solrClient;
+    private final SolrClient solrClient;
 
     @Inject
     private Instance<LoggedInUser> loggedInUserInstance;
@@ -74,7 +74,7 @@ public class ZoekenService {
         final SolrQuery query = new SolrQuery("*:*");
 
         if (loggedInUserInstance.get() != null) { // SignaleringenJob heeft geen ingelogde gebruiker
-            applyAllowedZaaktypenPolicy(query);
+            applyAllowedDomeinenForUserPolicy(query);
         }
 
         if (zoekParameters.getType() != null) {
@@ -179,15 +179,15 @@ public class ZoekenService {
         }
     }
 
-    private void applyAllowedZaaktypenPolicy(final SolrQuery query) {
-        final Set<String> allowedZaaktypen = policyService.getAllowedZaaktypen();
-        if (allowedZaaktypen != null) {
-            if (allowedZaaktypen.isEmpty()) {
-                query.addFilterQuery(format("%s:%s", ZAAKTYPE_OMSCHRIJVING_VELD, NON_EXISTING_ZAAKTYPE));
+    private void applyAllowedDomeinenForUserPolicy(final SolrQuery query) {
+        final Set<String> userDomeinen = policyService.getAllowedDomeinenForUser();
+        if (userDomeinen != null) {
+            if (userDomeinen.isEmpty()) {
+                query.addFilterQuery(format("%s:%s", ZAAKTYPE_DOMEIN_VELD, NON_EXISTING_DOMEIN));
             } else {
-                query.addFilterQuery(allowedZaaktypen.stream()
+                query.addFilterQuery(userDomeinen.stream()
                                              .map(ZoekenService::quoted)
-                                             .map(zaaktype -> format("%s:%s", ZAAKTYPE_OMSCHRIJVING_VELD, zaaktype))
+                                             .map(domein -> format("%s:%s", ZAAKTYPE_DOMEIN_VELD, domein))
                                              .collect(joining(" OR ")));
             }
         }

--- a/src/main/java/net/atos/zac/zoeken/converter/DocumentZoekObjectConverter.java
+++ b/src/main/java/net/atos/zac/zoeken/converter/DocumentZoekObjectConverter.java
@@ -18,6 +18,8 @@ import net.atos.zac.enkelvoudiginformatieobject.EnkelvoudigInformatieObjectLockS
 import net.atos.zac.enkelvoudiginformatieobject.model.EnkelvoudigInformatieObjectLock;
 import net.atos.zac.identity.IdentityService;
 import net.atos.zac.util.DateTimeConverterUtil;
+import net.atos.zac.zaaksturing.ZaakafhandelParameterService;
+import net.atos.zac.zaaksturing.model.ZaakafhandelParameters;
 import net.atos.zac.zoeken.model.DocumentIndicatie;
 import net.atos.zac.zoeken.model.index.ZoekObjectType;
 import net.atos.zac.zoeken.model.zoekobject.DocumentZoekObject;
@@ -42,6 +44,8 @@ public class DocumentZoekObjectConverter extends AbstractZoekObjectConverter<Doc
     @Inject
     private EnkelvoudigInformatieObjectLockService enkelvoudigInformatieObjectLockService;
 
+    @Inject
+    private ZaakafhandelParameterService zaakafhandelParameterService;
 
     @Override
     public DocumentZoekObject convert(final String documentUUID) {
@@ -67,6 +71,9 @@ public class DocumentZoekObjectConverter extends AbstractZoekObjectConverter<Doc
         documentZoekObject.setTitel(informatieobject.getTitel());
         documentZoekObject.setBeschrijving(informatieobject.getBeschrijving());
         documentZoekObject.setZaaktypeOmschrijving(zaaktype.getOmschrijving());
+        final ZaakafhandelParameters zaakafhandelParameters =
+                zaakafhandelParameterService.readZaakafhandelParameters(zaaktype.getUUID());
+        documentZoekObject.setZaaktypeDomein(zaakafhandelParameters.getDomein());
         documentZoekObject.setZaaktypeUuid(zaaktype.getUUID().toString());
         documentZoekObject.setZaaktypeIdentificatie(zaaktype.getIdentificatie());
         documentZoekObject.setZaakIdentificatie(zaak.getIdentificatie());

--- a/src/main/java/net/atos/zac/zoeken/converter/TaakZoekObjectConverter.java
+++ b/src/main/java/net/atos/zac/zoeken/converter/TaakZoekObjectConverter.java
@@ -15,10 +15,11 @@ import net.atos.client.zgw.ztc.ZTCClientService;
 import net.atos.client.zgw.ztc.model.Zaaktype;
 import net.atos.zac.flowable.TaakVariabelenService;
 import net.atos.zac.flowable.TakenService;
-import net.atos.zac.flowable.ZaakVariabelenService;
 import net.atos.zac.identity.IdentityService;
 import net.atos.zac.identity.model.Group;
 import net.atos.zac.identity.model.User;
+import net.atos.zac.zaaksturing.ZaakafhandelParameterService;
+import net.atos.zac.zaaksturing.model.ZaakafhandelParameters;
 import net.atos.zac.zoeken.model.index.ZoekObjectType;
 import net.atos.zac.zoeken.model.zoekobject.TaakZoekObject;
 
@@ -31,9 +32,6 @@ public class TaakZoekObjectConverter extends AbstractZoekObjectConverter<TaakZoe
     private TakenService takenService;
 
     @Inject
-    private ZaakVariabelenService zaakVariabelenService;
-
-    @Inject
     private TaakVariabelenService taakVariabelenService;
 
     @Inject
@@ -41,6 +39,9 @@ public class TaakZoekObjectConverter extends AbstractZoekObjectConverter<TaakZoe
 
     @Inject
     private ZRCClientService zrcClientService;
+
+    @Inject
+    private ZaakafhandelParameterService zaakafhandelParameterService;
 
     @Override
     public TaakZoekObject convert(final String taskID) {
@@ -73,8 +74,11 @@ public class TaakZoekObjectConverter extends AbstractZoekObjectConverter<TaakZoe
         final Zaaktype zaaktype = ztcClientService.readZaaktype(
                 taakVariabelenService.readZaaktypeUUID(taskInfo));
         taakZoekObject.setZaaktypeIdentificatie(zaaktype.getIdentificatie());
-        taakZoekObject.setZaaktypeOmschrijving(zaaktype.getOmschrijving());
         taakZoekObject.setZaaktypeUuid(zaaktype.getUUID().toString());
+        taakZoekObject.setZaaktypeOmschrijving(zaaktype.getOmschrijving());
+        final ZaakafhandelParameters zaakafhandelParameters =
+                zaakafhandelParameterService.readZaakafhandelParameters(zaaktype.getUUID());
+        taakZoekObject.setZaaktypeDomein(zaakafhandelParameters.getDomein());
 
         final UUID zaakUUID = taakVariabelenService.readZaakUUID(taskInfo);
         taakZoekObject.setZaakUUID(zaakUUID.toString());

--- a/src/main/java/net/atos/zac/zoeken/model/zoekobject/DocumentZoekObject.java
+++ b/src/main/java/net/atos/zac/zoeken/model/zoekobject/DocumentZoekObject.java
@@ -44,6 +44,9 @@ public class DocumentZoekObject implements ZoekObject {
     @Field("informatieobject_zaaktypeOmschrijving")
     private String zaaktypeOmschrijving;
 
+    @Field("informatieobject_zaaktypeDomein")
+    private String zaaktypeDomein;
+
     @Field("informatieobject_zaakId")
     private String zaakIdentificatie;
 
@@ -179,6 +182,14 @@ public class DocumentZoekObject implements ZoekObject {
 
     public void setZaaktypeOmschrijving(final String zaaktypeOmschrijving) {
         this.zaaktypeOmschrijving = zaaktypeOmschrijving;
+    }
+
+    public String getZaaktypeDomein() {
+        return zaaktypeDomein;
+    }
+
+    public void setZaaktypeDomein(final String zaaktypeDomein) {
+        this.zaaktypeDomein = zaaktypeDomein;
     }
 
     public String getZaakIdentificatie() {

--- a/src/main/java/net/atos/zac/zoeken/model/zoekobject/TaakZoekObject.java
+++ b/src/main/java/net/atos/zac/zoeken/model/zoekobject/TaakZoekObject.java
@@ -42,6 +42,9 @@ public class TaakZoekObject implements ZoekObject {
     @Field("taak_zaaktypeOmschrijving")
     private String zaaktypeOmschrijving;
 
+    @Field("taak_zaaktypeDomein")
+    private String zaaktypeDomein;
+
     @Field("taak_zaakUuid")
     private String zaakUUID;
 
@@ -135,6 +138,14 @@ public class TaakZoekObject implements ZoekObject {
 
     public void setZaaktypeOmschrijving(final String zaaktypeOmschrijving) {
         this.zaaktypeOmschrijving = zaaktypeOmschrijving;
+    }
+
+    public String getZaaktypeDomein() {
+        return zaaktypeDomein;
+    }
+
+    public void setZaaktypeDomein(final String zaaktypeDomein) {
+        this.zaaktypeDomein = zaaktypeDomein;
     }
 
     public String getZaaktypeUuid() {

--- a/src/main/java/net/atos/zac/zoeken/model/zoekobject/ZaakZoekObject.java
+++ b/src/main/java/net/atos/zac/zoeken/model/zoekobject/ZaakZoekObject.java
@@ -112,6 +112,9 @@ public class ZaakZoekObject implements ZoekObject {
     @Field("zaak_zaaktypeOmschrijving")
     private String zaaktypeOmschrijving;
 
+    @Field("zaak_zaaktypeDomein")
+    private String zaaktypeDomein;
+
     @Field("zaak_resultaattypeOmschrijving")
     private String resultaattypeOmschrijving;
 
@@ -358,6 +361,14 @@ public class ZaakZoekObject implements ZoekObject {
 
     public void setZaaktypeOmschrijving(final String zaaktypeOmschrijving) {
         this.zaaktypeOmschrijving = zaaktypeOmschrijving;
+    }
+
+    public String getZaaktypeDomein() {
+        return zaaktypeDomein;
+    }
+
+    public void setZaaktypeDomein(final String zaaktypeDomein) {
+        this.zaaktypeDomein = zaaktypeDomein;
     }
 
     public String getResultaattypeOmschrijving() {

--- a/src/main/resources/policies/document-rechten.rego
+++ b/src/main/resources/policies/document-rechten.rego
@@ -4,8 +4,8 @@ import future.keywords
 import data.net.atos.zac.rol.behandelaar
 import data.net.atos.zac.rol.coordinator
 import data.net.atos.zac.rol.recordmanager
-import data.net.atos.zac.domein.domeinen
-import data.net.atos.zac.domein.domein_elk_zaaktype
+import data.net.atos.zac.rol.rollen
+import data.net.atos.zac.domein.ALLE_DOMEINEN
 import input.user
 import input.document
 
@@ -18,17 +18,16 @@ document_rechten := {
     "ondertekenen": ondertekenen
 }
 
-default zaaktype_allowed := false
-zaaktype_allowed {
-    not document.zaaktype
+default domein_allowed := false
+domein_allowed {
+    not document.domein
 }
-zaaktype_allowed {
-    domein_elk_zaaktype.rol in user.rollen
+domein_allowed {
+    ALLE_DOMEINEN in user.rollen
 }
-zaaktype_allowed {
-    some domein
-    domeinen[domein].rol in user.rollen
-    document.zaaktype in domeinen[domein].zaaktypen
+domein_allowed {
+    not document.domein in rollen
+    document.domein in user.rollen
 }
 
 default onvergrendeld_of_vergrendeld_door_user := false
@@ -43,55 +42,55 @@ onvergrendeld_of_vergrendeld_door_user {
 default lezen := false
 lezen {
     { behandelaar, coordinator, recordmanager }[_].rol in user.rollen
-    zaaktype_allowed
+    domein_allowed
 }
 
 default wijzigen := false
 wijzigen {
     behandelaar.rol in user.rollen
-    zaaktype_allowed
+    domein_allowed
     document.zaak_open == true
     document.definitief == false
     onvergrendeld_of_vergrendeld_door_user == true
 }
 wijzigen {
     recordmanager.rol in user.rollen
-    zaaktype_allowed
+    domein_allowed
 }
 
 default verwijderen := false
 verwijderen {
     recordmanager.rol in user.rollen
-    zaaktype_allowed
+    domein_allowed
 }
 
 default vergrendelen := false
 vergrendelen {
     behandelaar.rol in user.rollen
-    zaaktype_allowed
+    domein_allowed
     document.zaak_open == true
     document.definitief == false
 }
 vergrendelen {
     recordmanager.rol in user.rollen
-    zaaktype_allowed
+    domein_allowed
 }
 
 default ontgrendelen := false
 ontgrendelen {
     behandelaar.rol in user.rollen
-    zaaktype_allowed
+    domein_allowed
     document.vergrendeld_door == user.id
 }
 ontgrendelen {
     recordmanager.rol in user.rollen
-    zaaktype_allowed
+    domein_allowed
 }
 
 default ondertekenen := false
 ondertekenen {
     behandelaar.rol in user.rollen
-    zaaktype_allowed
+    domein_allowed
     document.zaak_open == true
     onvergrendeld_of_vergrendeld_door_user == true
 }

--- a/src/main/resources/policies/domeinen.rego
+++ b/src/main/resources/policies/domeinen.rego
@@ -1,35 +1,3 @@
 package net.atos.zac.domein
 
-domein_elk_zaaktype := {
-    "rol": "domein_elk_zaaktype",
-    "zaaktypen": { "-ALLE-ZAAKTYPEN-" }
-}
-
-domeinen := [
-    domein_elk_zaaktype,
-    {
-        "rol": "domein_kampen",
-        "zaaktypen": { "Aanvragen evenementenvergunning beoordelen" }
-    },
-    {
-        "rol": "domein_dowr",
-        "zaaktypen": { "Subsidie" }
-    },
-    {
-        "rol": "domein_laarbeek",
-        "zaaktypen": { "Aanleg uitweg" }
-    },
-    {
-       "rol": "domein_oost_gelre",
-       "zaaktypen": { "Toeristenbelastingen" }
-    },
-    {
-       "rol": "domein_oldenzaal",
-       "zaaktypen": { "Wegenbeheer en onderhoud" }
-    },
-    {
-       "rol": "domein_overig",
-       "zaaktypen": { "Melding klein evenement" }
-    }
-]
-
+ALLE_DOMEINEN := "domein_elk_zaaktype"

--- a/src/main/resources/policies/policies
+++ b/src/main/resources/policies/policies
@@ -1,6 +1,5 @@
 rollen.rego
 domeinen.rego
-zaaktypen.rego
 zaak-rechten.rego
 taak-rechten.rego
 document-rechten.rego

--- a/src/main/resources/policies/rollen.rego
+++ b/src/main/resources/policies/rollen.rego
@@ -19,3 +19,12 @@ beheerder := {
 functioneel := {
     "rol": "functionele_gebruiker"
 }
+
+rollen[rol]{
+    rol := [behandelaar
+           ,coordinator
+           ,recordmanager
+           ,beheerder
+           ,functioneel
+           ][i].rol
+}

--- a/src/main/resources/policies/taak-rechten.rego
+++ b/src/main/resources/policies/taak-rechten.rego
@@ -3,8 +3,8 @@ package net.atos.zac.taak
 import future.keywords
 import data.net.atos.zac.rol.behandelaar
 import data.net.atos.zac.rol.recordmanager
-import data.net.atos.zac.domein.domeinen
-import data.net.atos.zac.domein.domein_elk_zaaktype
+import data.net.atos.zac.rol.rollen
+import data.net.atos.zac.domein.ALLE_DOMEINEN
 import input.user
 import input.taak
 
@@ -14,30 +14,29 @@ taak_rechten := {
     "toekennen": toekennen,
 }
 
-default zaaktype_allowed := false
-zaaktype_allowed {
-    domein_elk_zaaktype.rol in user.rollen
+default domein_allowed := false
+domein_allowed {
+    ALLE_DOMEINEN in user.rollen
 }
-zaaktype_allowed {
-    some domein
-    domeinen[domein].rol in user.rollen
-    taak.zaaktype in domeinen[domein].zaaktypen
+domein_allowed {
+    not taak.domein in rollen
+    taak.domein in user.rollen
 }
 
 default lezen := false
 lezen {
     { behandelaar, recordmanager }[_].rol in user.rollen
-    zaaktype_allowed == true
+    domein_allowed == true
 }
 
 default wijzigen := false
 wijzigen {
     { behandelaar, recordmanager }[_].rol in user.rollen
-    zaaktype_allowed == true
+    domein_allowed == true
 }
 
 default toekennen := false
 toekennen {
     behandelaar.rol in user.rollen
-    zaaktype_allowed == true
+    domein_allowed == true
 }

--- a/src/main/resources/policies/zaak-rechten.rego
+++ b/src/main/resources/policies/zaak-rechten.rego
@@ -4,8 +4,8 @@ import future.keywords
 import data.net.atos.zac.rol.behandelaar
 import data.net.atos.zac.rol.coordinator
 import data.net.atos.zac.rol.recordmanager
-import data.net.atos.zac.domein.domeinen
-import data.net.atos.zac.domein.domein_elk_zaaktype
+import data.net.atos.zac.rol.rollen
+import data.net.atos.zac.domein.ALLE_DOMEINEN
 import input.zaak
 import input.user
 
@@ -19,59 +19,58 @@ zaak_rechten := {
     "wijzigenDoorlooptijd": wijzigenDoorlooptijd
 }
 
-default zaaktype_allowed := false
-zaaktype_allowed {
-    domein_elk_zaaktype.rol in user.rollen
+default domein_allowed := false
+domein_allowed {
+    ALLE_DOMEINEN in user.rollen
 }
-zaaktype_allowed {
-    some domein
-    domeinen[domein].rol in user.rollen
-    zaak.zaaktype in domeinen[domein].zaaktypen
+domein_allowed {
+    not zaak.domein in rollen
+    zaak.domein in user.rollen
 }
 
 default lezen := false
 lezen {
     { behandelaar, coordinator, recordmanager }[_].rol in user.rollen
-    zaaktype_allowed == true
+    domein_allowed == true
 }
 
 default wijzigen := false
 wijzigen {
     behandelaar.rol in user.rollen
-    zaaktype_allowed == true
+    domein_allowed == true
     zaak.open == true
 }
 wijzigen {
     recordmanager.rol in user.rollen
-    zaaktype_allowed == true
+    domein_allowed == true
 }
 
 default toekennen := false
 toekennen {
     { behandelaar, coordinator, recordmanager }[_].rol in user.rollen
-    zaaktype_allowed == true
+    domein_allowed == true
 }
 
 default behandelen := false
 behandelen {
     behandelaar.rol in user.rollen
-    zaaktype_allowed == true
+    domein_allowed == true
 }
 
 default afbreken := false
 afbreken {
     { behandelaar, recordmanager }[_].rol in user.rollen
-    zaaktype_allowed == true
+    domein_allowed == true
 }
 
 default heropenen := false
 heropenen {
     recordmanager.rol in user.rollen
-    zaaktype_allowed == true
+    domein_allowed == true
 }
 
 default wijzigenDoorlooptijd := false
 wijzigenDoorlooptijd {
     recordmanager.rol in user.rollen
-    zaaktype_allowed == true
+    domein_allowed == true
 }

--- a/src/main/resources/policies/zaaktypen.rego
+++ b/src/main/resources/policies/zaaktypen.rego
@@ -1,9 +1,0 @@
-package net.atos.zac.zaaktype
-
-import future.keywords
-import data.net.atos.zac.domein.domeinen
-import input.user
-
-zaaktypen[domein_zaaktypen] {
-    domein_zaaktypen := union({ zaaktype | domeinen[i].rol in user.rollen; zaaktype := domeinen[i].zaaktypen })
-}


### PR DESCRIPTION
Dit zijn de aanpassingen aan de autorisatie. Here be rego dragons. ;-)

Nu nog het herindexeren als een zaaktype aan een ander domain gekoppeld wordt.

En dat zit er nu ook bij. (Ook nog even het gebruik van URIUtil gefixt en een mogelijk race conditie gevolg in het markeren van de herindexeren voorkomen.)