### PR TITLE
zaakafhandelcomponent-2138 Fix interpretatie van Duration bij verlengen zaak

### DIFF
--- a/src/main/java/net/atos/zac/app/zaken/converter/RESTZaaktypeConverter.java
+++ b/src/main/java/net/atos/zac/app/zaken/converter/RESTZaaktypeConverter.java
@@ -5,6 +5,9 @@
 
 package net.atos.zac.app.zaken.converter;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
 import javax.inject.Inject;
 
 import net.atos.client.zgw.ztc.model.Zaaktype;
@@ -37,7 +40,8 @@ public class RESTZaaktypeConverter {
         restZaaktype.opschortingMogelijk = zaaktype.getOpschortingEnAanhoudingMogelijk();
         restZaaktype.verlengingMogelijk = zaaktype.getVerlengingMogelijk();
         if (restZaaktype.verlengingMogelijk) {
-            restZaaktype.verlengingstermijn = zaaktype.getVerlengingstermijn().getDays();
+            LocalDateTime start = LocalDateTime.now();
+            restZaaktype.verlengingstermijn = Long.valueOf(start.until(start.plus(zaaktype.getVerlengingstermijn()), ChronoUnit.DAYS)).intValue();
         }
 
         if (zaaktype.getReferentieproces() != null) {

--- a/src/main/java/net/atos/zac/app/zaken/converter/RESTZaaktypeConverter.java
+++ b/src/main/java/net/atos/zac/app/zaken/converter/RESTZaaktypeConverter.java
@@ -5,14 +5,12 @@
 
 package net.atos.zac.app.zaken.converter;
 
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-
 import javax.inject.Inject;
 
 import net.atos.client.zgw.ztc.model.Zaaktype;
 import net.atos.zac.app.admin.converter.RESTZaakafhandelParametersConverter;
 import net.atos.zac.app.zaken.model.RESTZaaktype;
+import net.atos.zac.util.PeriodUtil;
 import net.atos.zac.util.UriUtil;
 import net.atos.zac.zaaksturing.ZaakafhandelParameterService;
 import net.atos.zac.zaaksturing.model.ZaakafhandelParameters;
@@ -40,8 +38,7 @@ public class RESTZaaktypeConverter {
         restZaaktype.opschortingMogelijk = zaaktype.getOpschortingEnAanhoudingMogelijk();
         restZaaktype.verlengingMogelijk = zaaktype.getVerlengingMogelijk();
         if (restZaaktype.verlengingMogelijk) {
-            LocalDateTime start = LocalDateTime.now();
-            restZaaktype.verlengingstermijn = Long.valueOf(start.until(start.plus(zaaktype.getVerlengingstermijn()), ChronoUnit.DAYS)).intValue();
+            restZaaktype.verlengingstermijn = PeriodUtil.aantalDagenVanafHeden(zaaktype.getVerlengingstermijn());
         }
 
         if (zaaktype.getReferentieproces() != null) {

--- a/src/main/java/net/atos/zac/util/PeriodUtil.java
+++ b/src/main/java/net/atos/zac/util/PeriodUtil.java
@@ -5,7 +5,9 @@
 
 package net.atos.zac.util;
 
+import java.time.LocalDateTime;
 import java.time.Period;
+import java.time.temporal.ChronoUnit;
 
 public final class PeriodUtil {
 
@@ -51,5 +53,13 @@ public final class PeriodUtil {
             }
             return buf.toString();
         }
+    }
+
+    public static int aantalDagenVanafHeden(Period period) {
+        if (period == null) {
+            return 0;
+        }
+        LocalDateTime start = LocalDateTime.now();
+        return Long.valueOf(start.until(start.plus(period), ChronoUnit.DAYS)).intValue();
     }
 }


### PR DESCRIPTION
Fixes #2138.

Note: De oplossing voelt overbodig complex vanwege de meerdere calls naar een `LocalDateTime`, maar de `Period`-klasse kan van een periode van 1 maand (`P1M`) geen exacte match naar een aantal dagen maken zonder deze te vergelijken met een reference point (in deze oplossing de huidige datum) (zie o.a. het gekozen antwoord op [deze stackoverflow post](https://stackoverflow.com/questions/41893900/java-time-period-to-seconds)). Een alternatieve oplossing zou zijn de hele validation van het form component aan de front-end te wijzigen zodat hier een period meegegeven kan worden, maar dit voelt overengineerd voor het probleem.