### PR TITLE
zaakafhandelcomponent-2326 Medewerker-Groep fixes

### DIFF
--- a/src/main/app/src/app/shared/edit/edit-groep-behandelaar/edit-groep-behandelaar.component.html
+++ b/src/main/app/src/app/shared/edit/edit-groep-behandelaar/edit-groep-behandelaar.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos
+  ~ SPDX-FileCopyrightText: 2022 - 2023 Atos
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 <div (click)="edit()" *ngIf="!editing" class="view">
@@ -43,13 +43,13 @@
 
     <div class="form-buttons">
         <div>
-            <button (click)="assignToMe()" *ngIf="showAssignToMe | async" color="accent" id="behandelaarKenAanMijToe_button"
+            <button (click)="assignToMe()" [hidden]="!showAssignToMe" color="accent" id="behandelaarKenAanMijToe_button"
                     mat-mini-fab
                     title="{{'actie.mij.toekennen' | translate}}">
                 <mat-icon>person_add_alt_1</mat-icon>
             </button>
 
-            <button (click)="release()" *ngIf="getFormControl('medewerker').defaultValue" color="accent" id="behandelaarVrijgeven_button"
+            <button (click)="release()" [hidden]="!showRelease" color="accent" id="behandelaarVrijgeven_button"
                     mat-mini-fab
                     title="{{'actie.vrijgeven' | translate}}">
                 <mat-icon>person_remove_alt</mat-icon>

--- a/src/main/app/src/app/shared/edit/edit-groep-behandelaar/edit-groep-behandelaar.component.ts
+++ b/src/main/app/src/app/shared/edit/edit-groep-behandelaar/edit-groep-behandelaar.component.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Atos
+ * SPDX-FileCopyrightText: 2021 - 2023 Atos
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
@@ -12,7 +12,6 @@ import {EditComponent} from '../edit.component';
 import {MedewerkerGroepFormField} from '../../material-form-builder/form-components/medewerker-groep/medewerker-groep-form-field';
 import {FormControl} from '@angular/forms';
 import {LoggedInUser} from '../../../identity/model/logged-in-user';
-import {Subject, Subscription} from 'rxjs';
 
 @Component({
     selector: 'zac-edit-groep-behandelaar',
@@ -23,8 +22,6 @@ export class EditGroepBehandelaarComponent extends EditComponent implements OnIn
 
     @Input() formField: MedewerkerGroepFormField;
     @Input() reasonField: InputFormField;
-    showAssignToMe = new Subject<boolean>();
-    groepSubscription: Subscription;
     private loggedInUser: LoggedInUser;
 
     constructor(mfbService: MaterialFormBuilderService, utilService: UtilService, private identityService: IdentityService) {
@@ -36,18 +33,15 @@ export class EditGroepBehandelaarComponent extends EditComponent implements OnIn
 
     ngOnInit(): void {
         super.ngOnInit();
-        this.groepSubscription = this.formField.groep.valueChanges.subscribe(_ => this.updateShowAssignToMe());
     }
 
     ngOnDestroy(): void {
         super.ngOnDestroy();
-        this.groepSubscription.unsubscribe();
     }
 
     edit(): void {
         super.edit();
 
-        this.updateShowAssignToMe();
         if (this.reasonField) {
             this.formFields.setControl('reden', this.reasonField.formControl);
         }
@@ -65,8 +59,12 @@ export class EditGroepBehandelaarComponent extends EditComponent implements OnIn
         return this.formField.formControl.get(control) as FormControl;
     }
 
-    updateShowAssignToMe(): void {
-        this.showAssignToMe.next(this.loggedInUser.id !== this.formField.medewerker.value?.id &&
-            this.loggedInUser.groupIds.indexOf(this.formField.groep.value.id) >= 0);
+    get showAssignToMe(): boolean {
+        return this.loggedInUser.id !== this.formField.medewerker.value?.id &&
+            this.loggedInUser.groupIds.indexOf(this.formField.groep.value.id) >= 0;
+    }
+
+    get showRelease(): boolean {
+        return this.formField.medewerker.value !== null;
     }
 }


### PR DESCRIPTION
Fixes #2326.

Ook wat algemene verbeteringen aan het herbruikbare edit-groep-behandelaar-component. Vanwege de subscriptions en alle calls die nodig zijn om die te updaten werd dat complexer dan nodig. De `hidden` param ipv `ngIf`-directive is nodig omdat de `zacOutsideClick`-directive anders faalt omdat het element niet meer in de DOM zit.