### PR TITLE
zaakafhandelcomponent-2303 Nette melding tonen bij afsluiten zaak

### DIFF
--- a/src/main/java/net/atos/zac/app/zaken/ZakenRESTService.java
+++ b/src/main/java/net/atos/zac/app/zaken/ZakenRESTService.java
@@ -137,6 +137,7 @@ import net.atos.zac.identity.IdentityService;
 import net.atos.zac.identity.model.Group;
 import net.atos.zac.identity.model.User;
 import net.atos.zac.policy.PolicyService;
+import net.atos.zac.shared.exception.FoutmeldingException;
 import net.atos.zac.shared.helper.OpschortenZaakHelper;
 import net.atos.zac.signalering.SignaleringenService;
 import net.atos.zac.signalering.model.SignaleringType;
@@ -622,7 +623,10 @@ public class ZakenRESTService {
     public void afsluiten(@PathParam("uuid") final UUID zaakUUID, final RESTZaakAfsluitenGegevens afsluitenGegevens) {
         Zaak zaak = zrcClientService.readZaak(zaakUUID);
         assertPolicy(zaak.isOpen() && policyService.readZaakRechten(zaak)
-                .getBehandelen() && !zrcClientService.heeftOpenDeelzaken(zaak));
+                .getBehandelen());
+        if (zrcClientService.heeftOpenDeelzaken(zaak)) {
+            throw new FoutmeldingException("Deze hoofdzaak heeft open deelzaken en kan niet afgesloten worden.");
+        }
         zgwApiService.updateResultaatForZaak(zaak, afsluitenGegevens.resultaattypeUuid, afsluitenGegevens.reden);
         zgwApiService.closeZaak(zaak, afsluitenGegevens.reden);
     }


### PR DESCRIPTION
Fixes #2303.

Iets andere oplossing dan in het issue stond. Dit beperkt de nieuwe dependencies die je anders moet introduceren om de EventListenerPlanItems te filteren op de juiste plek. De knop is dus wel zichtbaar, maar er wordt een nette melding getoond als je probeert een zaak met open deelzaken af te sluiten.