### PR TITLE
zaakafhandelcomponent-2168 Verplaats naar herbruikbaar component

### DIFF
--- a/src/main/app/src/app/informatie-objecten/informatie-object-view/informatie-object-view.component.html
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-view/informatie-object-view.component.html
@@ -40,9 +40,8 @@
                                                      [value]="'vertrouwelijkheidaanduiding.'+infoObject.vertrouwelijkheidaanduiding | translate"></zac-static-text>
                                     <zac-static-text [label]="'bestandsnaam' | translate"
                                                      [value]="infoObject.bestandsnaam">
-                                        <span position="content-before"
-                                              class="fa-solid {{getFileIcon(infoObject.bestandsnaam).icon}} {{getFileIcon(infoObject.bestandsnaam).color}}"
-                                              [title]="getFileTooltip(getFileIcon(infoObject.bestandsnaam).type)">&nbsp;</span>
+                                        <zac-document-icon position="content-before" [document]="infoObject"></zac-document-icon>
+                                        <span position="content-before">&nbsp;</span>
                                     </zac-static-text>
                                 </div>
                                 <div class="w33 w50-sm">

--- a/src/main/app/src/app/informatie-objecten/informatie-object-view/informatie-object-view.component.less
+++ b/src/main/app/src/app/informatie-objecten/informatie-object-view/informatie-object-view.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Atos
+ * SPDX-FileCopyrightText: 2021 - 2023 Atos
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
@@ -7,24 +7,4 @@
 .historie-table {
   height: 400px;
   overflow: auto;
-}
-
-.blue {
-  color: blue;
-}
-
-.green {
-  color: green;
-}
-
-.orange {
-  color: orange;
-}
-
-.red {
-  color: red;
-}
-
-.darkred {
-  color: darkred;
 }

--- a/src/main/app/src/app/informatie-objecten/model/file-icon.ts
+++ b/src/main/app/src/app/informatie-objecten/model/file-icon.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos
+ * SPDX-FileCopyrightText: 2022 - 2023 Atos
  * SPDX-License-Identifier: EUPL-1.2+
  */
 

--- a/src/main/app/src/app/shared/document-titel/document-icon.component.html
+++ b/src/main/app/src/app/shared/document-titel/document-icon.component.html
@@ -1,0 +1,2 @@
+<span class="fa-solid {{getFileIcon(document.bestandsnaam).icon}} {{getFileIcon(document.bestandsnaam).color}}"
+      [title]="getFileTooltip(getFileIcon(document.bestandsnaam).type)"></span>

--- a/src/main/app/src/app/shared/document-titel/document-icon.component.less
+++ b/src/main/app/src/app/shared/document-titel/document-icon.component.less
@@ -1,0 +1,19 @@
+.blue {
+  color: blue;
+}
+
+.green {
+  color: green;
+}
+
+.orange {
+  color: orange;
+}
+
+.red {
+  color: red;
+}
+
+.darkred {
+  color: darkred;
+}

--- a/src/main/app/src/app/shared/document-titel/document-icon.component.ts
+++ b/src/main/app/src/app/shared/document-titel/document-icon.component.ts
@@ -1,0 +1,26 @@
+import {Component, Input} from '@angular/core';
+import {EnkelvoudigInformatieobject} from '../../informatie-objecten/model/enkelvoudig-informatieobject';
+import {FileIcon} from '../../informatie-objecten/model/file-icon';
+import {TranslateService} from '@ngx-translate/core';
+
+@Component({
+    selector: 'zac-document-icon',
+    templateUrl: './document-icon.component.html',
+    styleUrls: ['./document-icon.component.less']
+})
+export class DocumentIconComponent {
+
+    @Input() document: EnkelvoudigInformatieobject;
+
+    constructor(private translate: TranslateService) {
+    }
+
+    getFileIcon(filename) {
+        return FileIcon.getIconByBestandsnaam(filename);
+    }
+
+    getFileTooltip(filetype: string): string {
+        return this.translate.instant('bestandstype', {type: filetype.toUpperCase()});
+    }
+
+}

--- a/src/main/app/src/app/shared/document-titel/document-icon.module.ts
+++ b/src/main/app/src/app/shared/document-titel/document-icon.module.ts
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Atos
+ * SPDX-License-Identifier: EUPL-1.2+
+ */
+
+import {NgModule} from '@angular/core';
+import {DocumentIconComponent} from './document-icon.component';
+
+@NgModule({
+    declarations: [
+        DocumentIconComponent
+    ],
+    exports: [
+        DocumentIconComponent
+    ]
+})
+export class DocumentIconModule {
+}

--- a/src/main/app/src/app/shared/material-form-builder/form-components/documenten-lijst/documenten-lijst.component.html
+++ b/src/main/app/src/app/shared/material-form-builder/form-components/documenten-lijst/documenten-lijst.component.html
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2022 Atos
+  ~ SPDX-FileCopyrightText: 2022 - 2023 Atos
   ~ SPDX-License-Identifier: EUPL-1.2+
   -->
 
@@ -26,7 +26,10 @@
                 </ng-container>
                 <ng-container matColumnDef="titel">
                     <th mat-header-cell *matHeaderCellDef> {{'titel' | translate}} </th>
-                    <td mat-cell *matCellDef="let document"> {{document.titel}} </td>
+                    <td mat-cell *matCellDef="let document">
+                        <zac-document-icon [document]="document"></zac-document-icon>
+                        {{document.titel}}
+                    </td>
                 </ng-container>
                 <ng-container matColumnDef="documentType">
                     <th mat-header-cell *matHeaderCellDef> {{'documentType' | translate}} </th>

--- a/src/main/app/src/app/shared/material-form-builder/material-form-builder.module.ts
+++ b/src/main/app/src/app/shared/material-form-builder/material-form-builder.module.ts
@@ -53,6 +53,7 @@ import {NgxEditorModule} from 'ngx-editor';
 import {HtmlEditorVariabelenKiesMenuComponent} from './form-components/html-editor/html-editor-variabelen-kies-menu.component';
 import {MatMenuModule} from '@angular/material/menu';
 import {MatListModule} from '@angular/material/list';
+import {DocumentIconModule} from '../document-titel/document-icon.module';
 
 @NgModule({
     declarations: [
@@ -105,7 +106,8 @@ import {MatListModule} from '@angular/material/list';
         MatDividerModule,
         NgxEditorModule,
         MatMenuModule,
-        MatListModule
+        MatListModule,
+        DocumentIconModule
     ],
     exports: [
         FormComponent,

--- a/src/main/app/src/app/shared/shared.module.ts
+++ b/src/main/app/src/app/shared/shared.module.ts
@@ -50,6 +50,7 @@ import {ToggleFilterComponent} from './table-zoek-filters/toggle-filter/toggle-f
 import {ZaakIndicatiesComponent} from './indicaties/zaak-indicaties/zaak-indicaties.component';
 import {InformatieObjectIndicatiesComponent} from './indicaties/informatie-object-indicaties/informatie-object-indicaties.component';
 import {VersionComponent} from './version/version.component';
+import {DocumentIconModule} from './document-titel/document-icon.module';
 
 @NgModule({
     declarations: [
@@ -95,7 +96,8 @@ import {VersionComponent} from './version/version.component';
         MaterialFormBuilderModule.forRoot(),
         TranslateModule,
         PdfJsViewerModule,
-        NgxSkeletonLoaderModule.forRoot({animation: 'pulse'})
+        NgxSkeletonLoaderModule.forRoot({animation: 'pulse'}),
+        DocumentIconModule
     ],
     exports: [
         BrowserAnimationsModule,
@@ -134,7 +136,8 @@ import {VersionComponent} from './version/version.component';
         ExportButtonComponent,
         InformatieObjectIndicatiesComponent,
         ZaakIndicatiesComponent,
-        VersionComponent
+        VersionComponent,
+        DocumentIconModule
     ],
     providers: [
         Title,

--- a/src/main/app/src/app/zaken/zaak-documenten/zaak-documenten.component.html
+++ b/src/main/app/src/app/zaken/zaak-documenten/zaak-documenten.component.html
@@ -35,9 +35,8 @@
                     <th mat-sort-header mat-header-cell *matHeaderCellDef> {{'titel' | translate}} </th>
                     <td mat-cell *matCellDef="let row" (click)="documentPreviewRow = documentPreviewRow === row ? null : row"
                         [ngClass]="{'pointer': isPreviewBeschikbaar(row.formaat)}">
-                        <span class="fa-solid {{getFileIcon(row.bestandsnaam).icon}} {{getFileIcon(row.bestandsnaam).color}}"
-                              [title]="getFileTooltip(getFileIcon(row.bestandsnaam).type)"></span>
-                        {{row.titel | empty}}
+                        <zac-document-icon [document]="row"></zac-document-icon>
+                        {{row.titel}}
                         <mat-icon *ngIf="isPreviewBeschikbaar(row.formaat)" class="material-icons-outlined">plagiarism</mat-icon>
                         <mat-icon *ngIf="row.startformulier" title="{{'startformulier' | translate}}" class="gold-star">star</mat-icon>
                     </td>

--- a/src/main/app/src/app/zaken/zaak-documenten/zaak-documenten.component.less
+++ b/src/main/app/src/app/zaken/zaak-documenten/zaak-documenten.component.less
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Atos
+ * SPDX-FileCopyrightText: 2022 - 2023 Atos
  * SPDX-License-Identifier: EUPL-1.2+
  */
 
@@ -12,22 +12,3 @@
   color: #000000;
 }
 
-.blue {
-  color: blue;
-}
-
-.green {
-  color: green;
-}
-
-.orange {
-  color: orange;
-}
-
-.red {
-  color: red;
-}
-
-.darkred {
-  color: darkred;
-}


### PR DESCRIPTION
Fixes #2168.

Herbruikbaar component ge&iuml;ntroduceerd om op verschillende plaatsen bijbehorend icoon voor een informatieobject te kunnen tonen. Voordat iemand valt over de toegevoegde module met maar &eacute;&eacute;n component er in - dit is nodig om het component ook te kunnen gebruiken in een sibling-module `material-form-builder` (component `documenten-lijst`).