### PR TITLE
Feature/fix docker push by renaming image

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -30,5 +30,35 @@ jobs:
       - name: Maven build
         run: mvn --batch-mode --update-snapshots package -DskipTests
 
+      - name: Cache Build Artefacts
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            target/
+          key: build-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
+
+  unit-tests:
+    needs: [build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Restore Build Artefacts
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            target/
+          key: build-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
+
+      - name: Run unit tests
+        run: mvn test --batch-mode -Dskip.npm
 
 

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -109,7 +109,7 @@ jobs:
             key: docker-image-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
 
   push-docker-image:
-    needs: [unit-tests, build-docker-image]
+    needs: [build, unit-tests, build-docker-image]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: github.ref == 'refs/heads/main'
@@ -134,5 +134,3 @@ jobs:
 
       - name: Push Docker Image
         run: docker push ${DOCKER_IMAGE_TAG}
-
-

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -10,7 +10,7 @@ on:
 env:
   JAVA_VERSION: '17'
   CONTAINER_REGISTRY_URL: 'ghcr.io/infonl'
-  APPLICATION_NAME: 'zaakafhandelcomponent'
+  APPLICATION_NAME: 'dimpact-zac'
 
 permissions:
   contents: write

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -1,0 +1,34 @@
+name: Build, Test & Deploy to Test.
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+env:
+  JAVA_VERSION: '17'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Maven build
+        run: mvn --batch-mode --update-snapshots package -DskipTests
+
+
+

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-name: Build, Test & Deploy to Test.
+name: Build, test & deploy
 
 on:
   pull_request:
@@ -9,6 +9,8 @@ on:
 
 env:
   JAVA_VERSION: '17'
+  CONTAINER_REGISTRY_URL: 'ghcr.io/infonl'
+  APPLICATION_NAME: 'zaakafhandelcomponent'
 
 permissions:
   contents: write
@@ -17,8 +19,24 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      branch_name: ${{ steps.gen_branch_name.outputs.BRANCH_NAME }}
+      build_number: ${{ steps.gen_build_number.outputs.BUILD_NUMBER }}
+      docker_image_tag: ${{ steps.gen_tag.outputs.DOCKER_IMAGE_TAG }}
     steps:
       - uses: actions/checkout@v3
+
+      - name: Set branch name
+        id: gen_branch_name
+        run: echo "BRANCH_NAME=${{ github.ref_name }}" | sed 's/\//_/g; s/(//g; s/)//g' >> $GITHUB_OUTPUT
+
+      - name: Set build number
+        id: gen_build_number
+        run: echo "BUILD_NUMBER=${{ steps.gen_branch_name.outputs.BRANCH_NAME }}-${{ github.run_number }}" >> $GITHUB_OUTPUT
+
+      - name: Set Docker image tag
+        id: gen_tag
+        run: echo "DOCKER_IMAGE_TAG=${{ env.CONTAINER_REGISTRY_URL }}/${{ env.APPLICATION_NAME }}:${{ steps.gen_build_number.outputs.BUILD_NUMBER }}" >> $GITHUB_OUTPUT
 
       - name: Setup JDK
         uses: actions/setup-java@v3
@@ -30,7 +48,7 @@ jobs:
       - name: Maven build
         run: mvn --batch-mode --update-snapshots package -DskipTests
 
-      - name: Cache Build Artefacts
+      - name: Cache build artefacts
         uses: actions/cache/save@v3
         with:
           path: |
@@ -51,7 +69,7 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      - name: Restore Build Artefacts
+      - name: Restore build artefacts
         uses: actions/cache/restore@v3
         with:
           path: |
@@ -60,5 +78,61 @@ jobs:
 
       - name: Run unit tests
         run: mvn test --batch-mode -Dskip.npm
+
+  build-docker-image:
+      needs: [build]
+      runs-on: ubuntu-latest
+      timeout-minutes: 30
+      env:
+        BUILD_NUMBER: ${{ needs.build.outputs.build_number }}
+        DOCKER_IMAGE_TAG: ${{ needs.build.outputs.docker_image_tag }}
+        GIT_COMMIT_HASH: ${{ github.sha }}
+      steps:
+        - uses: actions/checkout@v3
+
+        - name: Build Docker image
+          run: |
+            docker build --tag ${DOCKER_IMAGE_TAG} \
+            --build-arg versienummer=${BUILD_NUMBER} \
+            --build-arg buildId=${BUILD_NUMBER} \
+            --build-arg commit=${GIT_COMMIT_HASH} \
+            --file Containerfile \
+            .
+
+        - name: Save Docker Image
+          run: docker save --output docker-image.tar ${DOCKER_IMAGE_TAG}
+
+        - name: Cache Docker Image
+          uses: actions/cache/save@v3
+          with:
+            path: docker-image.tar
+            key: docker-image-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
+
+  push-docker-image:
+    needs: [unit-tests, build-docker-image]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.ref == 'refs/heads/main'
+    env:
+      DOCKER_IMAGE_TAG: ${{ needs.build.outputs.docker_image_tag }}
+    steps:
+      - name: Docker Login
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.CONTAINER_REGISTRY_URL }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Restore Docker Image
+        uses: actions/cache/restore@v3
+        with:
+          path: docker-image.tar
+          key: docker-image-${{ github.repository }}-${{ github.ref_name }}-${{ github.run_number }}
+
+      - name: Load Docker Image
+        run: docker load --input docker-image.tar
+
+      - name: Push Docker Image
+        run: docker push ${DOCKER_IMAGE_TAG}
 
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v2
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,12 +13,15 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches: [main]
   schedule:
-    - cron: '21 11 * * 0'
+    - cron: "21 11 * * 0"
+
+env:
+  JAVA_VERSION: "17"
 
 jobs:
   analyze:
@@ -32,13 +35,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'java', 'javascript' ]
+        language: ["java", "javascript"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: "temurin"
+          cache: maven
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 wildfly-*
 src/generated
 /.openapi-generator/*
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# dimpact-zaakafhandelcomponent
+This repo contains the code of the "zaakafhandel" component initially developed by Atos for Dimpact.


### PR DESCRIPTION
We currently have a GitHub Container registry with the name 'dimpact-zac'. Hence this is how we need to name our Docker image for now. Later on we should rename this to 'zaakafhandelcomponent'. Dimpact has no role to play in this. :-) 